### PR TITLE
fix(scalars): avoid letters in date field componente

### DIFF
--- a/src/ui/components/data-entry/date-picker/use-date-picker.tsx
+++ b/src/ui/components/data-entry/date-picker/use-date-picker.tsx
@@ -13,6 +13,7 @@ import {
   formatDateToValue,
   formatUTCDateToISOStringWithOutTime,
   getDateFromValue,
+  isFormatDisabled,
 } from "./utils.js";
 
 interface DatePickerFieldProps {
@@ -53,6 +54,9 @@ export const useDatePickerField = ({
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const inputValue = e.target.value;
+    if (isFormatDisabled(internalFormat, inputValue)) {
+      return;
+    }
     setInputDisplay(inputValue);
     onChange?.(createChangeEvent(inputValue));
   };

--- a/src/ui/components/data-entry/date-picker/utils.ts
+++ b/src/ui/components/data-entry/date-picker/utils.ts
@@ -128,3 +128,29 @@ export const formatUTCDateToISOStringWithOutTime = (date: Date): string => {
 export function swapAmbiguousDayMonthFormat(utcDate: Date, separator: string) {
   return `${utcDate.getUTCDate().toString().padStart(2, "0")}${separator}${(utcDate.getUTCMonth() + 1).toString().padStart(2, "0")}${separator}${utcDate.getUTCFullYear()}`;
 }
+
+
+/**
+ * Checks if letter input should be disabled based on the date format.
+ * For specific formats ('yyyy-MM-dd', 'dd/MM/yyyy', 'MM/dd/yyyy'), letter input is not allowed
+ * as these formats only accept numeric values.
+ *
+ * @param internalFormat - The internal date format being used
+ * @param inputValue - The current input value
+ * @returns True if letter input should be disabled (when using numeric-only formats), false otherwise
+ * @example
+ * isFormatDisabled('yyyy-MM-dd', 'abc') // returns true - letters not allowed
+ * isFormatDisabled('dd-MMM-yyyy', 'Jan') // returns false - letters allowed for month names
+ */
+export const isFormatDisabled = (
+  internalFormat: string | undefined,
+  inputValue = "",
+) => {
+  if (!internalFormat) return false;
+  const valuesToCheck = ["yyyy-MM-dd", "dd/MM/yyyy", "MM/dd/yyyy"];
+  return (
+    internalFormat &&
+    valuesToCheck.includes(internalFormat) &&
+    /[a-zA-Z]/.test(inputValue)
+  );
+};


### PR DESCRIPTION
## Ticket
https://trello.com/c/gQD0Heue/1013-date-fields-should-not-allow-letters

## Description
- Should make sure to enable and disable the letter depending of the selected format
