### PR TITLE
fix(scalars): focus tab component press letter should be open de popo…

### DIFF
--- a/src/ui/components/data-entry/select/select.tsx
+++ b/src/ui/components/data-entry/select/select.tsx
@@ -144,6 +144,14 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
                 type="button"
                 role="combobox"
                 onBlur={onTriggerBlur}
+                onKeyDown={(e) => {
+                  const shouldPreventOpening = isPopoverOpen || /^[0-9]$/.test(e.key) || !/^[a-zA-Z]$/.test(e.key);
+                  // Prevent opening for numbers and non-letter characters (only letters)
+                  if (shouldPreventOpening) {
+                    return;
+                  }
+                  handleOpenChange(true);
+                }}
                 disabled={disabled}
                 aria-invalid={errors.length > 0}
                 aria-label={


### PR DESCRIPTION
## Ticket
https://trello.com/c/dQU8XrOb/1012-cant-start-typing-in-the-country-selector-before-clicking

## Description
-  Should the search option be displayed if a letter is typed.