### PR TITLE
fix(scalars): fix date-time when not format is set

### DIFF
--- a/src/ui/components/data-entry/date-picker/utils.ts
+++ b/src/ui/components/data-entry/date-picker/utils.ts
@@ -146,10 +146,9 @@ export const isFormatDisabled = (
   internalFormat: string | undefined,
   inputValue = "",
 ) => {
-  if (!internalFormat) return false;
   const valuesToCheck = ["yyyy-MM-dd", "dd/MM/yyyy", "MM/dd/yyyy"];
   return (
-    internalFormat &&
+    internalFormat === undefined  ||
     valuesToCheck.includes(internalFormat) &&
     /[a-zA-Z]/.test(inputValue)
   );

--- a/src/ui/components/data-entry/date-time-picker/use-date-time-picker.tsx
+++ b/src/ui/components/data-entry/date-time-picker/use-date-time-picker.tsx
@@ -327,7 +327,7 @@ export const useDateTimePicker = ({
 
   const handleInputChangeField = (e: React.ChangeEvent<HTMLInputElement>) => {
     const inputValue = e.target.value;
-    
+
     if (isFormatDisabled(internalFormat, inputValue)) {
       return;
     }


### PR DESCRIPTION
## Ticket
https://trello.com/c/gQD0Heue/1013-date-fields-should-not-allow-letters


## Description
Still pending with default format:Environment: DateTimeField **Expected Output:** DateTimeField should allow letters only for the specified formats. The field always allows letters.  **Vis