### PR TITLE
fix(scalars): add the important rule to avoid override styles

### DIFF
--- a/src/ui/components/data-entry/date-picker/date-picker.tsx
+++ b/src/ui/components/data-entry/date-picker/date-picker.tsx
@@ -177,10 +177,10 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
             )}
             selectedClassName={cn(
               "rounded-[4px]",
-              "bg-gray-900 text-white",
+              "bg-gray-900 !text-white",
               "hover:bg-gray-900",
               // dark
-              "dark:bg-gray-50 dark:text-gray-900",
+              "dark:bg-gray-50 dark:!text-gray-900",
               "dark:hover:bg-gray-50 dark:hover:text-gray-900",
             )}
             dayButtonClassName={cn("text-[12px] font-medium")}

--- a/src/ui/components/data-entry/date-picker/date-picker.tsx
+++ b/src/ui/components/data-entry/date-picker/date-picker.tsx
@@ -150,8 +150,10 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
             dayClassName={cn(
               "w-[34px] cursor-pointer text-[12px] text-gray-900 hover:rounded-[4px] hover:bg-gray-200",
               // dark
-              "dark:text-gray-50 hover:dark:bg-gray-900",
+              "dark:text-gray-50 dark:hover:bg-gray-900",
               "disabled:text-gray-300",
+              // Remove hover when selected
+              "aria-selected:hover:bg-gray-900  dark:aria-selected:hover:bg-gray-50",
             )}
             buttonPreviousClassName={cn(
               "border border-gray-200",
@@ -177,10 +179,10 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
             )}
             selectedClassName={cn(
               "rounded-[4px]",
-              "bg-gray-900 !text-white",
-              "hover:bg-gray-900",
+              "bg-gray-900 text-white",
+              "hover:bg-gray-900 hover:text-white",
               // dark
-              "dark:bg-gray-50 dark:!text-gray-900",
+              "dark:bg-gray-50 dark:text-gray-900",
               "dark:hover:bg-gray-50 dark:hover:text-gray-900",
             )}
             dayButtonClassName={cn("text-[12px] font-medium")}


### PR DESCRIPTION
## Ticket
https://trello.com/c/UXaSGUbg/1026-the-date-picker-number-font-doesnt-change-colour-on-selection-apart-from-current-date-so-the-date-selected-is-unreadable

## Description
- Should apply the proper style for the selected date
