### PR TITLE
fix(scalars): allow show correct the value select from the calendar

### DIFF
--- a/src/ui/components/data-entry/date-picker/subcomponents/calendar/calendar.tsx
+++ b/src/ui/components/data-entry/date-picker/subcomponents/calendar/calendar.tsx
@@ -158,7 +158,7 @@ const Calendar = ({
   );
   const _selectedClassName = cn(
     "[&>button]:bg-primary [&>button]:text-primary-foreground [&>button]:hover:bg-primary [&>button]:hover:text-primary-foreground",
-    "rounded-[4px] bg-green-500",
+    "rounded-[4px] bg-gray-900 text-white dark:bg-gray-50 dark:text-gray-900",
     props.selectedClassName,
   );
   const _todayClassName = cn(


### PR DESCRIPTION
## Ticket
https://trello.com/c/UXaSGUbg/1026-the-date-picker-number-font-doesnt-change-colour-on-selection-apart-from-current-date-so-the-date-selected-is-unreadable

## Description
- Should apply the proper style for the selected date
