### PR TITLE
fix(scalars): add same style in calendar for date-time

### DIFF
--- a/src/scalars/components/date-time-picker-field/date-time-picker-field.tsx
+++ b/src/scalars/components/date-time-picker-field/date-time-picker-field.tsx
@@ -10,11 +10,11 @@ interface DateTimePickerFieldProps
   extends DateTimePickerProps,
     FieldErrorHandling {}
 
-const DateTimePickerField = withFieldValidation<DateTimePickerFieldProps>(
+const DateTimePickerField: React.FC<DateTimePickerFieldProps> = withFieldValidation<DateTimePickerFieldProps>(
   DateTimePicker,
   {
     validations: {
-      _timePickerType: dateTimeFieldValidations,
+      _dateTimePickerType: dateTimeFieldValidations,
     },
   },
 );

--- a/src/ui/components/data-entry/date-time-picker/date-time-picker-content.tsx
+++ b/src/ui/components/data-entry/date-time-picker/date-time-picker-content.tsx
@@ -129,10 +129,17 @@ const DateTimePickerContent = ({
             )}
             monthGridClassName={cn("w-full", "px-[5.5px]")}
             dayClassName={cn(
-              "w-[34px] cursor-pointer text-[12px] hover:rounded-[4px] hover:bg-gray-200 text-gray-900",
+              "w-[34px] cursor-pointer text-[12px] text-gray-900 hover:rounded-[4px] hover:bg-gray-200",
               // dark
-              "dark:text-gray-50 hover:dark:bg-gray-900",
+              "dark:text-gray-50 dark:hover:bg-gray-900",
+              // disabled
               "disabled:text-gray-300",
+              // Remove hover when selected
+              "aria-selected:hover:bg-gray-900 dark:aria-selected:hover:bg-gray-50",
+              // Selected state
+              "aria-selected:!bg-gray-900 aria-selected:!text-white",
+              // Dark mode selected state
+              "dark:aria-selected:!bg-gray-50 dark:aria-selected:!text-gray-900",
             )}
             buttonPreviousClassName={cn(
               "border border-gray-200",
@@ -154,11 +161,19 @@ const DateTimePickerContent = ({
               // dark
               "dark:bg-gray-900 dark:text-gray-50",
             )}
+            // selectedClassName={cn(
+            //   "rounded-[4px]",
+            //   "bg-gray-900 text-white",
+            //   "hover:bg-gray-900",
+            //   // dark
+            //   "dark:bg-gray-50 dark:text-gray-900",
+            //   "dark:hover:bg-gray-50 dark:hover:text-gray-900",
+            // )}
             selectedClassName={cn(
               "rounded-[4px]",
-              "bg-gray-900 text-white",
-              "hover:bg-gray-900",
-              // dark
+              "!bg-red-900 !text-white",
+              "hover:bg-gray-900 hover:text-white",
+              // // dark
               "dark:bg-gray-50 dark:text-gray-900",
               "dark:hover:bg-gray-50 dark:hover:text-gray-900",
             )}

--- a/src/ui/components/data-entry/date-time-picker/date-time-picker.tsx
+++ b/src/ui/components/data-entry/date-time-picker/date-time-picker.tsx
@@ -38,7 +38,7 @@ interface DateTimePickerProps extends InputBaseProps<DateFieldValue> {
   onChangeDate?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onBlurDate?: (e: React.FocusEvent<HTMLInputElement>) => void;
 }
-const DateTimePicker = forwardRef<HTMLInputElement, DateTimePickerProps>(
+const DateTimePicker: React.FC<DateTimePickerProps> = forwardRef<HTMLInputElement, DateTimePickerProps>(
   (
     {
       name,


### PR DESCRIPTION
## Ticket
https://trello.com/c/UXaSGUbg/1026-the-date-picker-number-font-doesnt-change-colour-on-selection-apart-from-current-date-so-the-date-selected-is-unreadable

## Description
- Should apply the proper style for the selected date
