### PR TITLE
docs: improve storybook structure

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -14,20 +14,14 @@ const preview: Preview = {
     options: {
       storySort: {
         order: [
-          'Connect',
-          'Powerhouse',
-          'RWA',
-          'Document Engineering',
-          [
-            'Getting started',
-            'Scalars',
-            ['Forms', 'Examples'],
-            'Data Entry',
-            'Data Display',
-            'Navigation',
-            'Layout Components',
-            'Fragments',
-          ],
+          'Getting started',
+          'Scalars',
+          ['Forms', 'Examples'],
+          'Data Entry',
+          'Data Display',
+          'Navigation',
+          'Layout Components',
+          'Fragments',
         ],
         method: 'alphabetical',
         includeNames: true,

--- a/src/scalars/components/aid-field/aid-field.stories.tsx
+++ b/src/scalars/components/aid-field/aid-field.stories.tsx
@@ -10,7 +10,7 @@ import {
 import { AIDField } from './aid-field.js'
 
 const meta: Meta<typeof AIDField> = {
-  title: 'Document Engineering/Scalars/AID Field',
+  title: 'Scalars/AID Field',
   component: AIDField,
   decorators: [
     withForm,

--- a/src/scalars/components/amount-field/amount-field.stories.tsx
+++ b/src/scalars/components/amount-field/amount-field.stories.tsx
@@ -18,7 +18,7 @@ const mappedCryptoCurrencies = commonCryptoCurrencies.map((currency) => ({
 }))
 
 const meta = {
-  title: 'Document Engineering/Scalars/Amount Field',
+  title: 'Scalars/Amount Field',
   component: AmountField,
   decorators: [withForm],
   parameters: {

--- a/src/scalars/components/boolean-field/boolean-field.stories.tsx
+++ b/src/scalars/components/boolean-field/boolean-field.stories.tsx
@@ -4,7 +4,7 @@ import { getDefaultArgTypes, getValidationArgTypes, StorybookControlCategory } f
 import { BooleanField } from './boolean-field.js'
 
 const meta = {
-  title: 'Document Engineering/Scalars/Boolean Field',
+  title: 'Scalars/Boolean Field',
   component: BooleanField,
   decorators: [withForm],
   argTypes: {
@@ -80,7 +80,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'A boolean field component that can be used as a [checkbox](?path=/docs/document-engineering-data-entry-checkbox--readme) or [toggle](?path=/docs/document-engineering-data-entry-toggle--readme) depending on the `isToggle` prop.',
+          'A boolean field component that can be used as a [checkbox](?path=/docs/data-entry-checkbox--readme) or [toggle](?path=/docs/data-entry-toggle--readme) depending on the `isToggle` prop.',
       },
     },
   },

--- a/src/scalars/components/country-code-field/country-code-field.stories.tsx
+++ b/src/scalars/components/country-code-field/country-code-field.stories.tsx
@@ -9,7 +9,7 @@ import {
 import { CountryCodeField } from './country-code-field.js'
 
 const meta: Meta<typeof CountryCodeField> = {
-  title: 'Document Engineering/Scalars/Country Code Field',
+  title: 'Scalars/Country Code Field',
   component: CountryCodeField,
   decorators: [
     withForm,

--- a/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
+++ b/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
@@ -4,7 +4,7 @@ import { getDefaultArgTypes, getValidationArgTypes, StorybookControlCategory } f
 import { CurrencyCodeField } from './currency-code-field.js'
 
 const meta: Meta<typeof CurrencyCodeField> = {
-  title: 'Document Engineering/Scalars/Currency Code Field',
+  title: 'Scalars/Currency Code Field',
   component: CurrencyCodeField,
   decorators: [withForm, (Story) => <div className="w-48">{Story()}</div>],
   parameters: {

--- a/src/scalars/components/date-picker-field/date-picker-field.stories.tsx
+++ b/src/scalars/components/date-picker-field/date-picker-field.stories.tsx
@@ -5,7 +5,7 @@ import { getDefaultArgTypes, getValidationArgTypes, StorybookControlCategory } f
 import { DatePickerField } from './date-picker-field.js'
 
 const meta: Meta<typeof DatePickerField> = {
-  title: 'Document Engineering/Scalars/Date Field',
+  title: 'Scalars/Date Field',
   component: DatePickerField,
   parameters: {
     layout: 'centered',

--- a/src/scalars/components/date-time-picker-field/date-time-picker-field.stories.tsx
+++ b/src/scalars/components/date-time-picker-field/date-time-picker-field.stories.tsx
@@ -5,7 +5,7 @@ import { getDefaultArgTypes, getValidationArgTypes, StorybookControlCategory } f
 import { DateTimePickerField } from './date-time-picker-field.js'
 
 const meta: Meta<typeof DateTimePickerField> = {
-  title: 'Document Engineering/Scalars/DateTimePickerField',
+  title: 'Scalars/DateTimePickerField',
   component: DateTimePickerField,
   decorators: [withForm],
   tags: ['autodocs'],

--- a/src/scalars/components/enum-field/enum-field.stories.tsx
+++ b/src/scalars/components/enum-field/enum-field.stories.tsx
@@ -11,7 +11,7 @@ import {
 import { EnumField } from './enum-field.js'
 
 const meta: Meta<typeof EnumField> = {
-  title: 'Document Engineering/Scalars/Enum Field',
+  title: 'Scalars/Enum Field',
   component: EnumField,
   decorators: [
     withForm,

--- a/src/scalars/components/examples/enum-field-example/enum-field-example.stories.tsx
+++ b/src/scalars/components/examples/enum-field-example/enum-field-example.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import EnumFieldExample from './enum-field-example.js'
 
 const meta = {
-  title: 'Document Engineering/Scalars/Examples/Enum Field Example',
+  title: 'Scalars/Examples/Enum Field Example',
   component: EnumFieldExample,
   tags: ['autodocs'],
   parameters: {

--- a/src/scalars/components/examples/multiple-fields-with-complex-layout/multiple-fields-with-complex-layout.stories.tsx
+++ b/src/scalars/components/examples/multiple-fields-with-complex-layout/multiple-fields-with-complex-layout.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import MultipleFieldsWithComplexLayout from './multiple-fields-with-complex-layout.js'
 
 const meta = {
-  title: 'Document Engineering/Scalars/Examples/Multiple Fields With Complex Layout',
+  title: 'Scalars/Examples/Multiple Fields With Complex Layout',
   component: MultipleFieldsWithComplexLayout,
   tags: ['autodocs'],
   parameters: {

--- a/src/scalars/components/examples/reset-button/reset-button.stories.tsx
+++ b/src/scalars/components/examples/reset-button/reset-button.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import FormWithResetButton from './reset-button.js'
 
 const meta = {
-  title: 'Document Engineering/Scalars/Examples/Reset Button',
+  title: 'Scalars/Examples/Reset Button',
   component: FormWithResetButton,
   tags: ['autodocs'],
   parameters: {

--- a/src/scalars/components/examples/reset-on-successful-submit/reset-on-successful-submit.stories.tsx
+++ b/src/scalars/components/examples/reset-on-successful-submit/reset-on-successful-submit.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import FormWithResetOnSuccessfulSubmit from './reset-on-successful-submit.js'
 
 const meta = {
-  title: 'Document Engineering/Scalars/Examples/Reset On Successful Submit',
+  title: 'Scalars/Examples/Reset On Successful Submit',
   component: FormWithResetOnSuccessfulSubmit,
   tags: ['autodocs'],
   parameters: {

--- a/src/scalars/components/examples/submit-changes-only/submit-changes-only.stories.tsx
+++ b/src/scalars/components/examples/submit-changes-only/submit-changes-only.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import SubmitChangesOnly, { DOCS_CODE } from './submit-changes-only.js'
 
 const meta = {
-  title: 'Document Engineering/Scalars/Examples/Submit Changes Only',
+  title: 'Scalars/Examples/Submit Changes Only',
   component: SubmitChangesOnly,
   tags: ['autodocs'],
   parameters: {

--- a/src/scalars/components/form/forms.mdx
+++ b/src/scalars/components/form/forms.mdx
@@ -4,7 +4,7 @@ import * as ResetButtonStories from "../examples/reset-button/reset-button.stori
 import * as ResetOnSuccessfulSubmitStories from "../examples/reset-on-successful-submit/reset-on-successful-submit.stories";
 import * as SubmitChangesOnly from "../examples/submit-changes-only/submit-changes-only.stories";
 
-<Meta title="Document Engineering/Scalars/Forms" />
+<Meta title="Scalars/Forms" />
 
 # Introduction
 

--- a/src/scalars/components/fragments/character-counter/character-counter.stories.tsx
+++ b/src/scalars/components/fragments/character-counter/character-counter.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { CharacterCounter } from './character-counter.js'
 
 const meta = {
-  title: 'Document Engineering/Fragments/CharacterCounter',
+  title: 'Fragments/CharacterCounter',
   component: CharacterCounter,
   parameters: {
     layout: 'centered',

--- a/src/scalars/components/fragments/form-description/form-description.stories.tsx
+++ b/src/scalars/components/fragments/form-description/form-description.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { FormDescription } from './form-description.js'
 
 const meta = {
-  title: 'Document Engineering/Fragments/FormDescription',
+  title: 'Fragments/FormDescription',
   component: FormDescription,
   parameters: {
     layout: 'centered',

--- a/src/scalars/components/fragments/form-label/form-label.stories.tsx
+++ b/src/scalars/components/fragments/form-label/form-label.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { FormLabel } from './form-label.js'
 
 const meta: Meta<typeof FormLabel> = {
-  title: 'Document Engineering/Fragments/FormLabel',
+  title: 'Fragments/FormLabel',
   component: FormLabel,
   parameters: {
     chromatic: {

--- a/src/scalars/components/fragments/form-message/form-message.stories.tsx
+++ b/src/scalars/components/fragments/form-message/form-message.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { FormMessage } from './form-message.js'
 
 const meta: Meta<typeof FormMessage> = {
-  title: 'Document Engineering/Fragments/FormMessage',
+  title: 'Fragments/FormMessage',
   component: FormMessage,
   parameters: {
     chromatic: {

--- a/src/scalars/components/id-field/id-field.stories.tsx
+++ b/src/scalars/components/id-field/id-field.stories.tsx
@@ -3,7 +3,7 @@ import { withForm } from '../../lib/decorators.js'
 import { IdField } from './id-field.js'
 
 const meta = {
-  title: 'Document Engineering/Scalars/Id Field',
+  title: 'Scalars/Id Field',
   component: IdField,
   decorators: [withForm],
   tags: ['autodocs'],

--- a/src/scalars/components/number-field/number-field.stories.tsx
+++ b/src/scalars/components/number-field/number-field.stories.tsx
@@ -9,7 +9,7 @@ import {
 import { NumberField } from './number-field.js'
 
 const meta = {
-  title: 'Document Engineering/Scalars/Number Field',
+  title: 'Scalars/Number Field',
   component: NumberField,
   parameters: {
     layout: 'centered',

--- a/src/scalars/components/oid-field/oid-field.stories.tsx
+++ b/src/scalars/components/oid-field/oid-field.stories.tsx
@@ -10,7 +10,7 @@ import {
 import { OIDField } from './oid-field.js'
 
 const meta: Meta<typeof OIDField> = {
-  title: 'Document Engineering/Scalars/OID Field',
+  title: 'Scalars/OID Field',
   component: OIDField,
   decorators: [
     withForm,

--- a/src/scalars/components/phid-field/phid-field.stories.tsx
+++ b/src/scalars/components/phid-field/phid-field.stories.tsx
@@ -10,7 +10,7 @@ import {
 import { PHIDField } from './phid-field.js'
 
 const meta: Meta<typeof PHIDField> = {
-  title: 'Document Engineering/Scalars/PHID Field',
+  title: 'Scalars/PHID Field',
   component: PHIDField,
   decorators: [
     withForm,

--- a/src/scalars/components/string-field/string-field.stories.tsx
+++ b/src/scalars/components/string-field/string-field.stories.tsx
@@ -9,7 +9,7 @@ import {
 import { StringField } from './string-field.js'
 
 const meta: Meta<typeof StringField> = {
-  title: 'Document Engineering/Scalars/String Field',
+  title: 'Scalars/String Field',
   component: StringField,
   decorators: [withForm, (Story) => <div className="w-48">{Story()}</div>],
   parameters: {

--- a/src/scalars/components/time-picker-field/time-picker-field.stories.tsx
+++ b/src/scalars/components/time-picker-field/time-picker-field.stories.tsx
@@ -4,7 +4,7 @@ import { getDefaultArgTypes, getValidationArgTypes, StorybookControlCategory } f
 import { TimePickerField } from './time-picker-field.js'
 
 const meta: Meta<typeof TimePickerField> = {
-  title: 'Document Engineering/Scalars/TimePickerField',
+  title: 'Scalars/TimePickerField',
   component: TimePickerField,
   parameters: {
     layout: 'centered',

--- a/src/scalars/components/url-field/url-field.stories.tsx
+++ b/src/scalars/components/url-field/url-field.stories.tsx
@@ -9,7 +9,7 @@ import {
 import { UrlField } from './url-field.js'
 
 const meta: Meta<typeof UrlField> = {
-  title: 'Document Engineering/Scalars/Url Field',
+  title: 'Scalars/Url Field',
   component: UrlField,
   decorators: [withForm],
   parameters: {

--- a/src/scalars/docs/getting-started.mdx
+++ b/src/scalars/docs/getting-started.mdx
@@ -1,6 +1,6 @@
 import { Meta, Source } from '@storybook/blocks';
 
-<Meta title="Document Engineering/Getting started" />
+<Meta title="Getting started" />
 
 # Document Engineering
 

--- a/src/ui/components/data-entry/aid-input/aid-input.stories.tsx
+++ b/src/ui/components/data-entry/aid-input/aid-input.stories.tsx
@@ -25,12 +25,12 @@ import { fetchOptions, fetchSelectedOption, mockedOptions } from './mocks.js'
  * - Async and sync options fetching
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [AIDField](?path=/docs/document-engineering-scalars-aid-field--readme)
+ * > you can use the [AIDField](?path=/docs/scalars-aid-field--readme)
  * > component.
  */
 
 const meta: Meta<typeof AIDInput> = {
-  title: 'Document Engineering/Data Entry/AID Input',
+  title: 'Data Entry/AID Input',
   component: AIDInput,
   decorators: [
     (Story) => (

--- a/src/ui/components/data-entry/amount-input/amount-input.stories.tsx
+++ b/src/ui/components/data-entry/amount-input/amount-input.stories.tsx
@@ -39,11 +39,11 @@ const mappedCryptoCurrencies = commonCryptoCurrencies.map((currency) => ({
  * - Multiple amount types (Fiat, Crypto, Percentage, etc.)
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [AmountField](?path=/docs/document-engineering-scalars-amount-field--readme)
+ * > you can use the [AmountField](?path=/docs/scalars-amount-field--readme)
  * > component.
  */
 const meta = {
-  title: 'Document Engineering/Data Entry/Amount Input',
+  title: 'Data Entry/Amount Input',
   component: AmountInput,
   parameters: {
     layout: 'centered',

--- a/src/ui/components/data-entry/checkbox/checkbox.stories.tsx
+++ b/src/ui/components/data-entry/checkbox/checkbox.stories.tsx
@@ -14,11 +14,11 @@ import { Checkbox } from './checkbox.js'
  * and can display error states. It also supports labels, descriptions, and validation messages.
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [BooleanField](?path=/docs/document-engineering-scalars-boolean-field--readme)
+ * > you can use the [BooleanField](?path=/docs/scalars-boolean-field--readme)
  * > component.
  */
 const meta = {
-  title: 'Document Engineering/Data Entry/Checkbox',
+  title: 'Data Entry/Checkbox',
   component: Checkbox,
   parameters: {
     layout: 'centered',

--- a/src/ui/components/data-entry/date-picker/date-picker.stories.tsx
+++ b/src/ui/components/data-entry/date-picker/date-picker.stories.tsx
@@ -24,11 +24,11 @@ import { DatePicker } from './date-picker.js'
  * - Custom placeholder support
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [DatePicker](?path=/docs/document-engineering-scalars-date-field--readme)
+ * > you can use the [DatePicker](?path=/docs/scalars-date-field--readme)
  * > component.
  */
 const meta: Meta<typeof DatePicker> = {
-  title: 'Document Engineering/Data Entry/Date Picker',
+  title: 'Data Entry/Date Picker',
   component: DatePicker,
   parameters: {
     layout: 'centered',

--- a/src/ui/components/data-entry/date-time-picker/date-time-picker.stories.tsx
+++ b/src/ui/components/data-entry/date-time-picker/date-time-picker.stories.tsx
@@ -29,12 +29,12 @@ import { FORMAT_MAPPING } from './utils.js'
  * - Custom placeholder support
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [DateTimePickerField](?path=/docs/document-engineering-scalars-datetimepickerfield--readme)
+ * > you can use the [DateTimePickerField](?path=/docs/scalars-datetimepickerfield--readme)
  * > component.
  */
 
 const meta: Meta<typeof DateTimePicker> = {
-  title: 'Document Engineering/Data Entry/Date Time Picker',
+  title: 'Data Entry/Date Time Picker',
   component: DateTimePicker,
   tags: ['autodocs'],
   decorators: [withTimestampsAsISOStrings],

--- a/src/ui/components/data-entry/input/input.stories.tsx
+++ b/src/ui/components/data-entry/input/input.stories.tsx
@@ -6,7 +6,7 @@ import { Input } from './input.js'
  * It has the standard `input` HTML element attributes and design system styles.
  */
 const meta = {
-  title: 'Document Engineering/Data Entry/Input',
+  title: 'Data Entry/Input',
   component: Input,
   parameters: {
     layout: 'centered',

--- a/src/ui/components/data-entry/oid-input/oid-input.stories.tsx
+++ b/src/ui/components/data-entry/oid-input/oid-input.stories.tsx
@@ -25,12 +25,12 @@ import { OIDInput } from './oid-input.js'
  * - Async and sync options fetching
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [OIDField](?path=/docs/document-engineering-scalars-oid-field--readme)
+ * > you can use the [OIDField](?path=/docs/scalars-oid-field--readme)
  * > component.
  */
 
 const meta: Meta<typeof OIDInput> = {
-  title: 'Document Engineering/Data Entry/OID Input',
+  title: 'Data Entry/OID Input',
   component: OIDInput,
   decorators: [
     (Story) => (

--- a/src/ui/components/data-entry/phid-input/phid-input.stories.tsx
+++ b/src/ui/components/data-entry/phid-input/phid-input.stories.tsx
@@ -25,12 +25,12 @@ import { PHIDInput } from './phid-input.js'
  * - Async and sync options fetching
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [PHIDField](?path=/docs/document-engineering-scalars-phid-field--readme)
+ * > you can use the [PHIDField](?path=/docs/scalars-phid-field--readme)
  * > component.
  */
 
 const meta: Meta<typeof PHIDInput> = {
-  title: 'Document Engineering/Data Entry/PHID Input',
+  title: 'Data Entry/PHID Input',
   component: PHIDInput,
   decorators: [
     (Story) => (

--- a/src/ui/components/data-entry/radio-group/radio-group.stories.tsx
+++ b/src/ui/components/data-entry/radio-group/radio-group.stories.tsx
@@ -22,12 +22,12 @@ import { RadioGroup } from './radio-group.js'
  * - Error and warning message display
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [EnumField](?path=/docs/document-engineering-scalars-enum-field--readme)
+ * > you can use the [EnumField](?path=/docs/scalars-enum-field--readme)
  * > component.
  */
 
 const meta: Meta<typeof RadioGroup> = {
-  title: 'Document Engineering/Data Entry/Radio Group',
+  title: 'Data Entry/Radio Group',
   component: RadioGroup,
   decorators: [
     (Story) => (

--- a/src/ui/components/data-entry/select/select.stories.tsx
+++ b/src/ui/components/data-entry/select/select.stories.tsx
@@ -30,12 +30,12 @@ import { Select } from './select.js'
  * - Disabled options support
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [EnumField](?path=/docs/document-engineering-scalars-enum-field--readme)
+ * > you can use the [EnumField](?path=/docs/scalars-enum-field--readme)
  * > component.
  */
 
 const meta: Meta<typeof Select> = {
-  title: 'Document Engineering/Data Entry/Select',
+  title: 'Data Entry/Select',
   component: Select,
   parameters: {
     layout: 'padded',

--- a/src/ui/components/data-entry/text-input/text-input.stories.tsx
+++ b/src/ui/components/data-entry/text-input/text-input.stories.tsx
@@ -12,11 +12,11 @@ import { TextInput } from './text-input.js'
  * It supports labels, descriptions, validation states, and text transformations.
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [StringField](?path=/docs/document-engineering-scalars-string-field--readme)
+ * > you can use the [StringField](?path=/docs/scalars-string-field--readme)
  * > component.
  */
 const meta = {
-  title: 'Document Engineering/Data Entry/Text Input',
+  title: 'Data Entry/Text Input',
   component: TextInput,
   parameters: {
     layout: 'centered',

--- a/src/ui/components/data-entry/textarea/textarea.stories.tsx
+++ b/src/ui/components/data-entry/textarea/textarea.stories.tsx
@@ -13,11 +13,11 @@ import { Textarea } from './textarea.js'
  * It also includes auto-expansion capabilities and character counting.
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [StringField](?path=/docs/document-engineering-scalars-string-field--readme)
+ * > you can use the [StringField](?path=/docs/scalars-string-field--readme)
  * > component.
  */
 const meta = {
-  title: 'Document Engineering/Data Entry/Textarea',
+  title: 'Data Entry/Textarea',
   component: Textarea,
   parameters: {
     layout: 'centered',

--- a/src/ui/components/data-entry/time-picker/time-picker.stories.tsx
+++ b/src/ui/components/data-entry/time-picker/time-picker.stories.tsx
@@ -19,12 +19,12 @@ import { TimePicker } from './time-picker'
  * - Custom placeholder support
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [TimePicker](?path=/docs/document-engineering-scalars-timepickerfield--readme)
+ * > you can use the [TimePicker](?path=/docs/scalars-timepickerfield--readme)
  * > component.
  */
 
 const meta: Meta<typeof TimePicker> = {
-  title: 'Document Engineering/Data Entry/Time Picker',
+  title: 'Data Entry/Time Picker',
   component: TimePicker,
   parameters: {
     layout: 'centered',

--- a/src/ui/components/data-entry/toggle/toggle.stories.tsx
+++ b/src/ui/components/data-entry/toggle/toggle.stories.tsx
@@ -14,11 +14,11 @@ import { Toggle } from './toggle.js'
  * and can display error states. It also supports labels, descriptions, and validation messages.
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [BooleanField](?path=/docs/document-engineering-scalars-boolean-field--readme)
+ * > you can use the [BooleanField](?path=/docs/scalars-boolean-field--readme)
  * > component and set the `isToggle` prop to `true`.
  */
 const meta = {
-  title: 'Document Engineering/Data Entry/Toggle',
+  title: 'Data Entry/Toggle',
   component: Toggle,
   parameters: {
     layout: 'centered',

--- a/src/ui/components/data-entry/url-input/url-input.stories.tsx
+++ b/src/ui/components/data-entry/url-input/url-input.stories.tsx
@@ -21,12 +21,12 @@ import { UrlInput } from './url-input.js'
  * - Trailing space trimming
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
- * > you can use the [UrlField](?path=/docs/document-engineering-scalars-url-field--readme)
+ * > you can use the [UrlField](?path=/docs/scalars-url-field--readme)
  * > component.
  */
 
 const meta: Meta<typeof UrlInput> = {
-  title: 'Document Engineering/Data Entry/Url Input',
+  title: 'Data Entry/Url Input',
   component: UrlInput,
   decorators: [
     (Story) => (

--- a/src/ui/components/dropdown/dropdown.stories.tsx
+++ b/src/ui/components/dropdown/dropdown.stories.tsx
@@ -165,7 +165,7 @@ import DropdownExample from './dropdown-example.js'
  * TypeScript users get full type checking for native div element props.
  */
 const meta: Meta<typeof DropdownExample> = {
-  title: 'Document Engineering/Data Display/Dropdown',
+  title: 'Data Display/Dropdown',
   component: DropdownExample,
   parameters: {
     layout: 'centered',

--- a/src/ui/components/icon/icon.stories.tsx
+++ b/src/ui/components/icon/icon.stories.tsx
@@ -3,7 +3,7 @@ import { iconNames } from '../icon-components/index.js'
 import { Icon } from './icon.js'
 
 const meta = {
-  title: 'UI/Icon',
+  title: 'Data Display/Icon',
   component: Icon,
   parameters: {
     layout: 'centered',

--- a/src/ui/components/icon/icon.tsx
+++ b/src/ui/components/icon/icon.tsx
@@ -1,6 +1,23 @@
-import { type Color, getDimensions, type Size } from '@powerhousedao/design-system'
-import { type ComponentPropsWithoutRef, Suspense } from 'react'
+import { type ComponentPropsWithoutRef, type CSSProperties, Suspense } from 'react'
 import { iconComponents, type IconName } from '../icon-components/index.js'
+
+export type Color = CSSProperties['color']
+export type Size = CSSProperties['width']
+export function getDimensions(size?: Size) {
+  if (!size) return {}
+
+  if (typeof size === 'number') {
+    return {
+      width: `${size}px`,
+      height: `${size}px`,
+    }
+  }
+
+  return {
+    width: size,
+    height: size,
+  }
+}
 
 type IconProps = ComponentPropsWithoutRef<'svg'> & {
   readonly name: IconName

--- a/src/ui/components/object-set-table/examples/computed-columns/computed-columns.stories.tsx
+++ b/src/ui/components/object-set-table/examples/computed-columns/computed-columns.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import ComputedColumnsExample from './computed-columns.js'
 
 const meta = {
-  title: 'Document Engineering/Data Display/Object Set Table/2 - Examples/Computed Columns',
+  title: 'Data Display/Object Set Table/2 - Examples/Computed Columns',
   component: ComputedColumnsExample,
   tags: ['autodocs'],
   parameters: {

--- a/src/ui/components/object-set-table/examples/custom-rendering/custom-rendering.stories.tsx
+++ b/src/ui/components/object-set-table/examples/custom-rendering/custom-rendering.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import CustomRenderingExample from './custom-rendering.js'
 
 const meta = {
-  title: 'Document Engineering/Data Display/Object Set Table/2 - Examples/Custom Rendering',
+  title: 'Data Display/Object Set Table/2 - Examples/Custom Rendering',
   component: CustomRenderingExample,
   tags: ['autodocs'],
   parameters: {

--- a/src/ui/components/object-set-table/object-set-table.stories.tsx
+++ b/src/ui/components/object-set-table/object-set-table.stories.tsx
@@ -285,7 +285,7 @@ import CustomRenderingExample from './examples/custom-rendering/custom-rendering
  * ```
  */
 const meta: Meta<typeof ObjectSetTable> = {
-  title: 'Document Engineering/Data Display/Object Set Table',
+  title: 'Data Display/Object Set Table',
   component: ObjectSetTable,
   tags: ['autodocs'],
   parameters: {

--- a/src/ui/components/sidebar/sidebar.stories.tsx
+++ b/src/ui/components/sidebar/sidebar.stories.tsx
@@ -81,7 +81,7 @@ import type { SidebarNode } from './types.js'
  * ```
  */
 const meta: Meta<typeof Sidebar> = {
-  title: 'Document Engineering/Navigation/Sidebar',
+  title: 'Navigation/Sidebar',
   component: Sidebar,
   tags: ['autodocs'],
   decorators: [

--- a/src/ui/components/tooltip/tooltip.stories.tsx
+++ b/src/ui/components/tooltip/tooltip.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Tooltip, TooltipProvider } from './tooltip.js'
 
 const meta: Meta<typeof Tooltip> = {
-  title: 'Document Engineering/Fragments/Tooltip',
+  title: 'Fragments/Tooltip',
   component: Tooltip,
   parameters: {
     layout: 'centered',


### PR DESCRIPTION
## Ticket
https://trello.com/c/2YI4cliE/1045-remove-ethereumaddress-component-and-reorganize-getting-started-in-storybook-navigation

## Description
- Removed "Document engineering" path from the storybook structure for better readability
- Removed EthereumAddress component
- Move Icon to Data display category
- Remove design-system dependency from the icon component
- Fixed internal storybook paths