### PR TITLE
fix(scalars): remove unnecesary border-0

### DIFF
--- a/src/ui/components/data-entry/amount-input/amount-input.tsx
+++ b/src/ui/components/data-entry/amount-input/amount-input.tsx
@@ -155,11 +155,9 @@ const AmountInputController = forwardRef<HTMLInputElement, AmountInputProps>(
               onFocus={handleIsInputFocused}
               placeholder={placeholder}
               className={cn(
-                currencyPosition === 'left' && 'rounded-l-none border border-l-[0.5px] border-gray-300',
-                currencyPosition === 'right' && 'rounded-r-none border border-r-[0.5px] border-gray-300',
+                currencyPosition === 'left' && 'rounded-l-none border-l-[0.5px]',
+                currencyPosition === 'right' && 'rounded-r-none border-r-[0.5px]',
                 isPercent && 'rounded-md pr-7',
-                // focus state
-                'focus:border-r-0',
                 isAmountWithoutUnit && 'rounded-md',
                 className
               )}


### PR DESCRIPTION
## Ticket
https://trello.com/c/iV03PjGR/757-9-amountfield

## Description
- Double border when the amount field has the input and the select visible
- When the field is active/receive focus the width changes