### PR TITLE
fix(scalars): fix input not typing when value its undefiend

### DIFF
--- a/src/ui/components/data-entry/amount-input/use-amount-input.tsx
+++ b/src/ui/components/data-entry/amount-input/use-amount-input.tsx
@@ -149,6 +149,13 @@ export const useAmountInput = ({
 
   // Handle the change of the input
   const handleOnChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (currentValue === undefined) {
+      const inputValue = e.target.value
+      const newValue = createAmountValue(inputValue)
+
+      const nativeEvent = handleEventOnChange(newValue)
+      onChange?.(nativeEvent)
+    }
     const inputValue = e.target.value
 
     if (type === 'AmountFiat' && typeof value === 'object') {


### PR DESCRIPTION
## Ticket
https://trello.com/c/iV03PjGR/757-9-amountfield

## Description
-  For amount currency, fiat and crypto, any currency is selected by default which shows the currency select empty by default. While no currency is selected, it doesn't allow to type in the input. With type="Amount" it never allows to type 
