### PR TITLE
fix(scalars): add missing dependencies to useEffect in use-id-autocomplete hook

### DIFF
--- a/src/scalars/components/fragments/id-autocomplete/use-id-autocomplete.ts
+++ b/src/scalars/components/fragments/id-autocomplete/use-id-autocomplete.ts
@@ -248,7 +248,7 @@ export function useIdAutocomplete({
         setSelectedOption(matchingOption)
       }
     }
-  }, [])
+  }, [initialOptions, selectedValue])
 
   return {
     selectedValue,


### PR DESCRIPTION
## Ticket
https://trello.com/c/F9R8s73V/990-fix-the-flickering-in-the-phid-when-is-an-array

## Description
- Should ensure that the PHID works properly after inserting a value that match an initial option.