### PR TITLE
fix(scalars): remove duplicate message in amount-field validations

### DIFF
--- a/src/scalars/components/amount-field/amount-field-validations.ts
+++ b/src/scalars/components/amount-field/amount-field-validations.ts
@@ -30,23 +30,13 @@ const getAmount = (value: AmountValue, type: AmountInputPropsGeneric['type']): n
 }
 
 export const validateAmount =
-  ({ type, required, minValue, maxValue, allowNegative }: AmountFieldProps) =>
+  ({ type, minValue, maxValue, allowNegative }: AmountFieldProps) =>
   (value: unknown): ValidatorResult => {
     const amount = getAmount(value as AmountValue, type)
-    if (value === '') return true
-    if (amount?.toString() === '') {
-      if (required) {
-        return 'This field is required'
-      }
+    if (amount === undefined) {
       return true
     }
 
-    if (amount === undefined) {
-      if (required) {
-        return 'This field is required'
-      }
-      return true
-    }
     if (!isValidNumber(amount) && type !== 'AmountCurrency') {
       return 'Value is not a valid number'
     }


### PR DESCRIPTION
## Ticket
https://trello.com/c/iV03PjGR/757-9-amountfield

## Description
A duplications errors appears when the field its required in the amountField component

## Solution
- Remove unnecessary check for when value its undefined: