### PR TITLE
fix: url diff mode when the original value and the value are equals

### DIFF
--- a/src/scalars/components/url-field/url-field.stories.tsx
+++ b/src/scalars/components/url-field/url-field.stories.tsx
@@ -58,16 +58,6 @@ const meta: Meta<typeof UrlField> = {
     ...getValidationArgTypes(),
 
     ...PrebuiltArgTypes.viewMode,
-    diffMode: {
-      control: 'select',
-      description: 'The mode of the input field',
-      options: ['sentences'],
-      table: {
-        type: { summary: 'sentences' },
-        defaultValue: { summary: 'sentences' },
-        category: StorybookControlCategory.DIFF,
-      },
-    },
     ...PrebuiltArgTypes.baseValue,
   },
   args: {

--- a/src/ui/components/data-entry/input/subcomponent/text-diff.tsx
+++ b/src/ui/components/data-entry/input/subcomponent/text-diff.tsx
@@ -1,6 +1,6 @@
 import { cn } from '../../../../../scalars/lib/utils.js'
 import type { WithDifference } from '../../../../../scalars/components/types.js'
-import { diffSentences, diffWords } from 'diff'
+import { type Change, diffSentences, diffWords } from 'diff'
 import { useMemo } from 'react'
 
 interface TextDiffProps extends WithDifference<string> {
@@ -21,73 +21,103 @@ export const TextDiff = ({
   asLink = false,
   icon,
 }: TextDiffProps) => {
-  const wordsDiff = useMemo(() => {
-    return diffMode === 'words' ? diffWords(baseValue ?? '', value) : diffSentences(baseValue ?? '', value)
+  const diff = useMemo(() => {
+    const base = baseValue ?? ''
+    return diffMode === 'words' ? diffWords(base, value) : diffSentences(base, value)
   }, [baseValue, value, diffMode])
 
-  const hasAdditions = useMemo(() => {
-    return wordsDiff.some((word) => word.added)
-  }, [wordsDiff])
+  const { hasAdditions, hasRemovals } = useMemo(() => {
+    return {
+      hasAdditions: diff.some((part) => part.added),
+      hasRemovals: diff.some((part) => part.removed),
+    }
+  }, [diff])
 
-  const hasRemovals = useMemo(() => {
-    return wordsDiff.some((word) => word.removed)
-  }, [wordsDiff])
+  // Get background color for sentence-level diffs
+  const getSentenceBackgroundColor = () => {
+    if (diffMode !== 'sentences' || (!hasAdditions && !hasRemovals)) {
+      return undefined
+    }
 
-  const bgColor =
-    diffMode === 'sentences' && (hasAdditions || hasRemovals)
-      ? viewMode === 'addition'
-        ? 'bg-green-600/30'
-        : viewMode === 'removal'
-          ? 'bg-red-600/30'
-          : undefined
-      : undefined
+    if (!viewMode) return undefined
 
-  // render the diff content
-  const renderDiffContent = () => {
-    return wordsDiff.map((word, index) => {
-      return word.added ? (
-        viewMode === 'addition' || viewMode === 'mixed' ? (
-          <span
-            className={cn((diffMode === 'words' || viewMode === 'mixed') && 'bg-green-600/30', childrenClassName)}
-            key={`${word.value}-${index}`}
-          >
-            {word.value}
-          </span>
-        ) : null
-      ) : word.removed ? (
-        viewMode === 'removal' || viewMode === 'mixed' ? (
-          <span
-            className={cn((diffMode === 'words' || viewMode === 'mixed') && 'bg-red-600/30', childrenClassName)}
-            key={`${word.value}-${index}`}
-          >
-            {word.value}
-          </span>
-        ) : null
-      ) : (
-        <span key={`${word.value}-${index}`} className={cn(childrenClassName)}>
-          {word.value}
-        </span>
-      )
-    })
+    switch (viewMode) {
+      case 'addition':
+        return 'bg-green-600/30'
+      case 'removal':
+        return 'bg-red-600/30'
+      case 'mixed':
+      case 'edition':
+      default:
+        return undefined
+    }
   }
 
-  return asLink && diffMode === 'sentences' ? (
-    <div className={cn('flex flex-1 items-center gap-2 truncate leading-[18px]', bgColor, className)}>
-      {((viewMode === 'addition' && hasAdditions) || (viewMode === 'removal' && hasRemovals)) && (
-        <>
-          {icon && icon}
-          <a
-            href={viewMode === 'removal' ? baseValue : value}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={cn('truncate text-blue-900 hover:underline focus-visible:outline-none')}
+  // Render individual diff parts
+  const renderDiffPart = (part: Change, index: number) => {
+    const key = `${part.value}-${index}`
+
+    // Handle added content
+    if (part.added) {
+      if (viewMode === 'addition' || viewMode === 'mixed') {
+        return (
+          <span
+            key={key}
+            className={cn((diffMode === 'words' || viewMode === 'mixed') && 'bg-green-600/30', childrenClassName)}
           >
-            {renderDiffContent()}
-          </a>
-        </>
-      )}
-    </div>
-  ) : (
-    <span className={cn('leading-[18px] text-gray-700', bgColor, className)}>{renderDiffContent()}</span>
-  )
+            {part.value}
+          </span>
+        )
+      }
+      return null
+    }
+
+    // Handle removed content
+    if (part.removed) {
+      if (viewMode === 'removal' || viewMode === 'mixed') {
+        return (
+          <span
+            key={key}
+            className={cn((diffMode === 'words' || viewMode === 'mixed') && 'bg-red-600/30', childrenClassName)}
+          >
+            {part.value}
+          </span>
+        )
+      }
+      return null
+    }
+
+    // Handle unchanged content - always render this
+    return (
+      <span key={key} className={cn(childrenClassName)}>
+        {part.value}
+      </span>
+    )
+  }
+
+  // Render all diff parts
+  const renderDiffContent = () => {
+    return diff.map(renderDiffPart).filter(Boolean)
+  }
+
+  const bgColor = getSentenceBackgroundColor()
+  const content = renderDiffContent()
+
+  if (asLink && diffMode === 'sentences') {
+    return (
+      <div className={cn('flex flex-1 items-center gap-2 truncate leading-[18px]', bgColor, className)}>
+        {icon && icon}
+        <a
+          href={viewMode === 'removal' ? baseValue : value}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn('truncate text-blue-900 hover:underline focus-visible:outline-none')}
+        >
+          {content}
+        </a>
+      </div>
+    )
+  }
+
+  return <span className={cn('leading-[18px] text-gray-700', bgColor, className)}>{content}</span>
 }

--- a/src/ui/components/data-entry/url-input/types.ts
+++ b/src/ui/components/data-entry/url-input/types.ts
@@ -1,9 +1,7 @@
-import type { DiffMode, InputBaseProps, WithDifference } from '../../../../scalars/components/types.js'
+import type { InputBaseProps, WithDifference } from '../../../../scalars/components/types.js'
 import type { IconName } from '../../icon/index.js'
 
-interface UrlInputWithDifference extends Omit<WithDifference<string>, 'diffMode'> {
-  diffMode?: Extract<DiffMode, 'sentences'>
-}
+type UrlInputWithDifference = Omit<WithDifference<string>, 'diffMode'>
 
 type PlatformIcon = IconName | React.ReactElement
 

--- a/src/ui/components/data-entry/url-input/url-input-diff.tsx
+++ b/src/ui/components/data-entry/url-input/url-input-diff.tsx
@@ -10,15 +10,7 @@ interface UrlInputDiffProps extends UrlInputWithDifference {
   platformIcons: UrlInputProps['platformIcons']
 }
 
-const UrlInputDiff = ({
-  value = '',
-  label,
-  required,
-  viewMode,
-  diffMode = 'sentences',
-  baseValue = '',
-  platformIcons,
-}: UrlInputDiffProps) => {
+const UrlInputDiff = ({ value = '', label, required, viewMode, baseValue = '', platformIcons }: UrlInputDiffProps) => {
   return (
     <FormGroup>
       {label && (
@@ -30,7 +22,7 @@ const UrlInputDiff = ({
         baseValue={baseValue}
         value={value}
         viewMode={viewMode}
-        diffMode={diffMode}
+        diffMode="sentences"
         asLink={true}
         platformIcons={platformIcons}
       />

--- a/src/ui/components/data-entry/url-input/url-input.stories.tsx
+++ b/src/ui/components/data-entry/url-input/url-input.stories.tsx
@@ -73,16 +73,6 @@ const meta: Meta<typeof UrlInput> = {
     }),
 
     ...PrebuiltArgTypes.viewMode,
-    diffMode: {
-      control: 'select',
-      description: 'The mode of the input field',
-      options: ['sentences'],
-      table: {
-        type: { summary: 'sentences' },
-        defaultValue: { summary: 'sentences' },
-        category: StorybookControlCategory.DIFF,
-      },
-    },
     ...PrebuiltArgTypes.baseValue,
   },
   args: {

--- a/src/ui/components/data-entry/url-input/url-input.tsx
+++ b/src/ui/components/data-entry/url-input/url-input.tsx
@@ -31,7 +31,6 @@ const UrlInput = React.forwardRef<HTMLInputElement, UrlInputProps>(
       onKeyDown,
       // diff props
       viewMode = 'edition',
-      diffMode,
       baseValue,
       ...props
     },
@@ -126,7 +125,6 @@ const UrlInput = React.forwardRef<HTMLInputElement, UrlInputProps>(
         label={label}
         required={required}
         viewMode={viewMode}
-        diffMode={diffMode}
         baseValue={baseValue}
         platformIcons={platformIcons}
       />


### PR DESCRIPTION
## Ticket
https://trello.com/c/iS9Q3Gns/1052-fix-urlinput-diff-display-when-basevalue-and-value-are-equal-and-non-empty

## Description
- fix issue when the URL inputs in diff mode doesn't show any value when the base value and the value are equals
- removed option of diff mode in URL as there's only one mode and it doesn't make sense to have it anymore
