### PR TITLE
fix(scalars): allow show the ceros, when trailingZeros its set

### DIFF
--- a/src/ui/components/data-entry/amount-input/utils.ts
+++ b/src/ui/components/data-entry/amount-input/utils.ts
@@ -58,7 +58,7 @@ export const displayValueAmount = (
     const formattedValue = parseFloat(value).toFixed(precision)
 
     // If the number of decimals is greater than or equal to the precision, apply toFixed
-    return parseFloat(formattedValue).toString()
+    return trailingZeros ? formattedValue : parseFloat(formattedValue).toString()
   }
 
   // If both are present, show the value with viewPrecision when focused


### PR DESCRIPTION
## Ticket
https://trello.com/c/iV03PjGR/757-9-amountfield


## Description
– When the trailingZeros prop is enabled, trailing zeros are not retained in the input display after the onBlur event.