### PR TITLE
feat(scalars & ui): add diff status to CountryCodePicker & CountryCodeField components

### DIFF
--- a/src/scalars/components/country-code-field/country-code-field.stories.tsx
+++ b/src/scalars/components/country-code-field/country-code-field.stories.tsx
@@ -52,7 +52,7 @@ const meta: Meta<typeof CountryCodeField> = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
-    viewMode: {
+    optionFormat: {
       control: 'radio',
       options: ['CodesOnly', 'NamesOnly', 'NamesAndCodes'],
       description: 'How to display country options in dropdown',
@@ -82,6 +82,9 @@ const meta: Meta<typeof CountryCodeField> = {
     },
 
     ...getValidationArgTypes(),
+
+    ...PrebuiltArgTypes.viewMode,
+    ...PrebuiltArgTypes.baseValue,
   },
   args: {
     name: 'country-code-field',
@@ -149,7 +152,7 @@ export const WithCodesOnly: Story = {
   args: {
     label: 'Country',
     description: 'Shows country codes only',
-    viewMode: 'CodesOnly',
+    optionFormat: 'CodesOnly',
   },
 }
 
@@ -157,7 +160,7 @@ export const WithNamesAndCodes: Story = {
   args: {
     label: 'Country',
     description: 'Shows country names and codes',
-    viewMode: 'NamesAndCodes',
+    optionFormat: 'NamesAndCodes',
   },
 }
 

--- a/src/scalars/components/enum-field/enum-field.stories.tsx
+++ b/src/scalars/components/enum-field/enum-field.stories.tsx
@@ -105,16 +105,6 @@ const meta: Meta<typeof EnumField> = {
     ...getValidationArgTypes(),
 
     ...PrebuiltArgTypes.viewMode,
-    diffMode: {
-      control: 'select',
-      description: 'The mode of the input field',
-      options: ['sentences'],
-      table: {
-        type: { summary: 'sentences' },
-        defaultValue: { summary: 'sentences' },
-        category: StorybookControlCategory.DIFF,
-      },
-    },
     ...PrebuiltArgTypes.baseValue,
   },
   args: {

--- a/src/scalars/components/enum-field/enum-field.stories.tsx
+++ b/src/scalars/components/enum-field/enum-field.stories.tsx
@@ -47,15 +47,31 @@ const meta: Meta<typeof EnumField> = {
 
     options: {
       control: 'object',
-      description: 'Array of options with label, value, icon, description and disabled',
+      description:
+        'Array of options with value, label, icon, description and disabled properties. These options will be displayed in the order they are provided.',
       table: {
         type: {
           summary:
-            'Array<{ label: string; value: string; icon?: IconName | React.ComponentType<{ className?: string }>; description?: string; disabled?: boolean; }>',
+            'Array<{ value: string; label: string; icon?: IconName | React.ComponentType<{ className?: string }>; description?: string; disabled?: boolean; }>',
         },
         defaultValue: { summary: '[]' },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
+    },
+
+    favoriteOptions: {
+      control: 'object',
+      description:
+        'Array of favorite options with value, label, icon and disabled properties. These options will be displayed at the top of the list.',
+      table: {
+        type: {
+          summary:
+            'Array<{ value: string; label: string; icon?: IconName | React.ComponentType<{ className?: string }>; disabled?: boolean; }>',
+        },
+        defaultValue: { summary: '[]' },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+      if: { arg: 'variant', neq: 'RadioGroup' },
     },
 
     multiple: {
@@ -105,7 +121,14 @@ const meta: Meta<typeof EnumField> = {
     ...getValidationArgTypes(),
 
     ...PrebuiltArgTypes.viewMode,
-    ...PrebuiltArgTypes.baseValue,
+    baseValue: {
+      control: 'object',
+      description: 'The base value of the enum field',
+      table: {
+        type: { summary: 'string | string[]' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
   },
   args: {
     name: 'enum-field',
@@ -317,5 +340,17 @@ export const WithCustomStylesRadioGroup: Story = {
     selectionIconPosition: 'right',
     className:
       '[&>label]:text-red-900 [&_label]:text-blue-600 [&_label]:hover:text-green-600 [&_button]:border-blue-600 [&_button]:hover:border-green-600 [&_[data-state=checked]_span]:after:!bg-red-500',
+  },
+}
+
+export const SelectWithDifferences: Story = {
+  args: {
+    label: 'Icon names comparison',
+    variant: 'Select',
+    options: defaultOptions,
+    value: ['Globe', 'Settings'],
+    baseValue: ['Briefcase', 'Drive'],
+    multiple: true,
+    viewMode: 'mixed',
   },
 }

--- a/src/scalars/components/enum-field/enum-field.tsx
+++ b/src/scalars/components/enum-field/enum-field.tsx
@@ -35,8 +35,11 @@ const EnumField = React.forwardRef<HTMLDivElement | HTMLButtonElement, EnumField
         return radio
       case 'Select':
         return select
-      case 'auto':
-        return options.length < 6 ? radio : select
+      case 'auto': {
+        const favoriteOptionsLength =
+          'favoriteOptions' in props && props.favoriteOptions !== undefined ? props.favoriteOptions.length : 0
+        return options.length + favoriteOptionsLength < 6 ? radio : select
+      }
     }
   }
 )

--- a/src/ui/components/data-entry/country-code-picker/country-code-picker-diff.tsx
+++ b/src/ui/components/data-entry/country-code-picker/country-code-picker-diff.tsx
@@ -1,14 +1,20 @@
 import { FormGroup, FormLabel } from '../../../../scalars/components/fragments/index.js'
 import { SplittedInputDiff } from '../input/splitted-input-diff.js'
-import type { SelectProps, SelectWithDifference } from './types.js'
+import type { CountryCodePickerProps, CountryCodePickerWithDifference } from './types.js'
 
-interface SelectDiffProps extends SelectWithDifference {
+interface CountryCodePickerDiffProps extends CountryCodePickerWithDifference {
   value: string
-  label: SelectProps['label']
-  required: SelectProps['required']
+  label: CountryCodePickerProps['label']
+  required: CountryCodePickerProps['required']
 }
 
-const SelectDiff = ({ value = '', label, required, viewMode, baseValue = '' }: SelectDiffProps) => {
+const CountryCodePickerDiff = ({
+  value = '',
+  label,
+  required,
+  viewMode,
+  baseValue = '',
+}: CountryCodePickerDiffProps) => {
   return (
     <FormGroup>
       {label && (
@@ -21,4 +27,4 @@ const SelectDiff = ({ value = '', label, required, viewMode, baseValue = '' }: S
   )
 }
 
-export { SelectDiff }
+export { CountryCodePickerDiff }

--- a/src/ui/components/data-entry/country-code-picker/country-code-picker.stories.tsx
+++ b/src/ui/components/data-entry/country-code-picker/country-code-picker.stories.tsx
@@ -68,7 +68,7 @@ const meta: Meta<typeof CountryCodePicker> = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
-    viewMode: {
+    optionFormat: {
       control: 'radio',
       options: ['CodesOnly', 'NamesOnly', 'NamesAndCodes'],
       description: 'How to display country options in dropdown',
@@ -104,6 +104,9 @@ const meta: Meta<typeof CountryCodePicker> = {
         showErrorOnChange: false,
       },
     }),
+
+    ...PrebuiltArgTypes.viewMode,
+    ...PrebuiltArgTypes.baseValue,
   },
   args: {
     name: 'country-code-picker',
@@ -171,7 +174,7 @@ export const WithCodesOnly: Story = {
   args: {
     label: 'Country',
     description: 'Shows country codes only',
-    viewMode: 'CodesOnly',
+    optionFormat: 'CodesOnly',
   },
 }
 
@@ -179,7 +182,7 @@ export const WithNamesAndCodes: Story = {
   args: {
     label: 'Country',
     description: 'Shows country names and codes',
-    viewMode: 'NamesAndCodes',
+    optionFormat: 'NamesAndCodes',
   },
 }
 

--- a/src/ui/components/data-entry/country-code-picker/country-code-picker.test.tsx
+++ b/src/ui/components/data-entry/country-code-picker/country-code-picker.test.tsx
@@ -124,4 +124,122 @@ describe('CountryCodePicker Component', () => {
 
     expect(screen.getByText('Puerto Rico')).toBeInTheDocument()
   })
+
+  // Tests for viewMode and diffs functionality
+  describe('viewMode and diffs', () => {
+    it('should render in edition mode by default', () => {
+      render(<CountryCodePicker {...defaultProps} />)
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
+    })
+
+    it('should render in edition mode when viewMode is explicitly set to edition', () => {
+      render(<CountryCodePicker {...defaultProps} viewMode="edition" />)
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is addition', () => {
+      render(<CountryCodePicker {...defaultProps} viewMode="addition" value="US" />)
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('United States')).toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is removal', () => {
+      render(<CountryCodePicker {...defaultProps} viewMode="removal" baseValue="United Kingdom" />)
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('United Kingdom')).toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is mixed', () => {
+      render(<CountryCodePicker {...defaultProps} viewMode="mixed" value="FR" baseValue="United States" />)
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('France')).toBeInTheDocument()
+      expect(screen.getByText('United States')).toBeInTheDocument()
+    })
+
+    it('should pass correct props to CountryCodePickerDiff component', () => {
+      render(<CountryCodePicker {...defaultProps} viewMode="mixed" value="US" baseValue="United Kingdom" required />)
+
+      // Verify label is rendered
+      expect(screen.getByText('Select Country')).toBeInTheDocument()
+
+      // Verify required indicator
+      expect(screen.getByText('*')).toBeInTheDocument()
+
+      // Verify the diff component is rendered (not the select)
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('United States')).toBeInTheDocument()
+      expect(screen.getByText('United Kingdom')).toBeInTheDocument()
+    })
+
+    it('should handle empty value in diff mode', () => {
+      const { container } = render(<CountryCodePicker {...defaultProps} viewMode="addition" value="" />)
+
+      // Verify that diff component is rendered instead of select
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('Select Country')).toBeInTheDocument()
+
+      // Find all span elements and verify they are empty
+      const diffSpans = container.querySelectorAll('span')
+      diffSpans.forEach((span) => {
+        expect(span).toHaveTextContent('')
+      })
+    })
+
+    it('should handle invalid country code in diff mode', () => {
+      render(<CountryCodePicker {...defaultProps} viewMode="addition" value="INVALID" />)
+
+      // Should fallback to showing the raw value when no matching option is found
+      expect(screen.getByText('INVALID')).toBeInTheDocument()
+    })
+
+    it('should respect optionFormat in diff mode', () => {
+      render(<CountryCodePicker {...defaultProps} viewMode="addition" value="US" optionFormat="NamesAndCodes" />)
+
+      // Should show "United States (US)" format
+      expect(screen.getByText('United States (US)')).toBeInTheDocument()
+    })
+
+    it('should respect optionFormat CodesOnly in diff mode', () => {
+      render(<CountryCodePicker {...defaultProps} viewMode="addition" value="US" optionFormat="CodesOnly" />)
+
+      // Should show just "US"
+      expect(screen.getByText('US')).toBeInTheDocument()
+    })
+
+    it('should work with filtered countries in diff mode', () => {
+      render(<CountryCodePicker {...defaultProps} viewMode="addition" value="US" allowedCountries={['US', 'GB']} />)
+
+      // Should show the correct country name even when filtered
+      expect(screen.getByText('United States')).toBeInTheDocument()
+    })
+
+    it('should handle dependent areas in diff mode', () => {
+      render(<CountryCodePicker {...defaultProps} viewMode="addition" value="PR" includeDependentAreas />)
+
+      // Should show Puerto Rico
+      expect(screen.getByText('Puerto Rico')).toBeInTheDocument()
+    })
+
+    it('should maintain all existing functionality in edition mode with new props present', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      render(
+        <CountryCodePicker
+          {...defaultProps}
+          viewMode="edition"
+          baseValue="US"
+          enableSearch
+          allowedCountries={['US', 'GB']}
+          onChange={onChange}
+        />
+      )
+
+      // Should still work as a normal select
+      const select = screen.getByRole('combobox')
+      await user.click(select)
+      await user.click(screen.getByText('United States'))
+      expect(onChange).toHaveBeenCalledWith('US')
+    })
+  })
 })

--- a/src/ui/components/data-entry/country-code-picker/country-code-picker.test.tsx
+++ b/src/ui/components/data-entry/country-code-picker/country-code-picker.test.tsx
@@ -138,108 +138,74 @@ describe('CountryCodePicker Component', () => {
     })
 
     it('should render diff component when viewMode is addition', () => {
-      render(<CountryCodePicker {...defaultProps} viewMode="addition" value="US" />)
+      render(<CountryCodePicker {...defaultProps} viewMode="addition" value="US" baseValue="GB" />)
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
       expect(screen.getByText('United States')).toBeInTheDocument()
+      expect(screen.queryByText('United Kingdom')).not.toBeInTheDocument()
     })
 
     it('should render diff component when viewMode is removal', () => {
-      render(<CountryCodePicker {...defaultProps} viewMode="removal" baseValue="United Kingdom" />)
+      render(<CountryCodePicker {...defaultProps} viewMode="removal" value="US" baseValue="GB" />)
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
       expect(screen.getByText('United Kingdom')).toBeInTheDocument()
+      expect(screen.queryByText('United States')).not.toBeInTheDocument()
     })
 
     it('should render diff component when viewMode is mixed', () => {
-      render(<CountryCodePicker {...defaultProps} viewMode="mixed" value="FR" baseValue="United States" />)
+      render(<CountryCodePicker {...defaultProps} viewMode="mixed" value="FR" baseValue="US" />)
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
       expect(screen.getByText('France')).toBeInTheDocument()
       expect(screen.getByText('United States')).toBeInTheDocument()
     })
 
     it('should pass correct props to CountryCodePickerDiff component', () => {
-      render(<CountryCodePicker {...defaultProps} viewMode="mixed" value="US" baseValue="United Kingdom" required />)
-
-      // Verify label is rendered
-      expect(screen.getByText('Select Country')).toBeInTheDocument()
-
-      // Verify required indicator
-      expect(screen.getByText('*')).toBeInTheDocument()
-
-      // Verify the diff component is rendered (not the select)
+      render(<CountryCodePicker {...defaultProps} viewMode="mixed" value="US" baseValue="GB" required />)
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('*')).toBeInTheDocument()
       expect(screen.getByText('United States')).toBeInTheDocument()
       expect(screen.getByText('United Kingdom')).toBeInTheDocument()
     })
 
     it('should handle empty value in diff mode', () => {
       const { container } = render(<CountryCodePicker {...defaultProps} viewMode="addition" value="" />)
-
-      // Verify that diff component is rendered instead of select
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
-      expect(screen.getByText('Select Country')).toBeInTheDocument()
-
-      // Find all span elements and verify they are empty
       const diffSpans = container.querySelectorAll('span')
       diffSpans.forEach((span) => {
         expect(span).toHaveTextContent('')
       })
     })
 
-    it('should handle invalid country code in diff mode', () => {
-      render(<CountryCodePicker {...defaultProps} viewMode="addition" value="INVALID" />)
-
-      // Should fallback to showing the raw value when no matching option is found
-      expect(screen.getByText('INVALID')).toBeInTheDocument()
+    it('should fallback to showing the raw value when no matching option is found', () => {
+      render(<CountryCodePicker {...defaultProps} viewMode="mixed" value="NEW" baseValue="OLD" />)
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('NEW')).toBeInTheDocument()
+      expect(screen.getByText('OLD')).toBeInTheDocument()
     })
 
     it('should respect optionFormat in diff mode', () => {
       render(<CountryCodePicker {...defaultProps} viewMode="addition" value="US" optionFormat="NamesAndCodes" />)
-
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
       // Should show "United States (US)" format
       expect(screen.getByText('United States (US)')).toBeInTheDocument()
     })
 
     it('should respect optionFormat CodesOnly in diff mode', () => {
       render(<CountryCodePicker {...defaultProps} viewMode="addition" value="US" optionFormat="CodesOnly" />)
-
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
       // Should show just "US"
       expect(screen.getByText('US')).toBeInTheDocument()
     })
 
     it('should work with filtered countries in diff mode', () => {
       render(<CountryCodePicker {...defaultProps} viewMode="addition" value="US" allowedCountries={['US', 'GB']} />)
-
-      // Should show the correct country name even when filtered
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
       expect(screen.getByText('United States')).toBeInTheDocument()
     })
 
     it('should handle dependent areas in diff mode', () => {
       render(<CountryCodePicker {...defaultProps} viewMode="addition" value="PR" includeDependentAreas />)
-
-      // Should show Puerto Rico
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
       expect(screen.getByText('Puerto Rico')).toBeInTheDocument()
-    })
-
-    it('should maintain all existing functionality in edition mode with new props present', async () => {
-      const user = userEvent.setup()
-      const onChange = vi.fn()
-
-      render(
-        <CountryCodePicker
-          {...defaultProps}
-          viewMode="edition"
-          baseValue="US"
-          enableSearch
-          allowedCountries={['US', 'GB']}
-          onChange={onChange}
-        />
-      )
-
-      // Should still work as a normal select
-      const select = screen.getByRole('combobox')
-      await user.click(select)
-      await user.click(screen.getByText('United States'))
-      expect(onChange).toHaveBeenCalledWith('US')
     })
   })
 })

--- a/src/ui/components/data-entry/country-code-picker/country-code-picker.tsx
+++ b/src/ui/components/data-entry/country-code-picker/country-code-picker.tsx
@@ -1,24 +1,34 @@
-import React from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { Select } from '../select/index.js'
 import { CircleFlag } from 'react-circle-flags'
 import countries, { type Countries } from 'world-countries'
+import { CountryCodePickerDiff } from './country-code-picker-diff.js'
 import type { CountryCodePickerProps } from './types.js'
 
 const CountryCodePicker = React.forwardRef<HTMLButtonElement, CountryCodePickerProps>(
   (
     {
+      label,
+      required,
+      value,
+      defaultValue,
       onChange,
       placeholder,
       allowedCountries,
       excludedCountries,
       includeDependentAreas = false,
-      viewMode = 'NamesOnly',
+      optionFormat = 'NamesOnly',
       showFlagIcons = true,
       enableSearch,
+      // diff props
+      viewMode = 'edition',
+      baseValue,
       ...props
     },
     ref
   ) => {
+    const [internalValue, setInternalValue] = useState(value ?? defaultValue ?? '')
+
     const defaultOptions = (countries as unknown as Countries)
       .filter(
         (country) => (includeDependentAreas ? true : country.independent) && country.cca2 !== 'AQ' // exclude Antarctica
@@ -26,9 +36,9 @@ const CountryCodePicker = React.forwardRef<HTMLButtonElement, CountryCodePickerP
       .map((country) => ({
         value: country.cca2,
         label:
-          viewMode === 'CodesOnly'
+          optionFormat === 'CodesOnly'
             ? country.cca2
-            : viewMode === 'NamesAndCodes'
+            : optionFormat === 'NamesAndCodes'
               ? `${country.name.common} (${country.cca2})`
               : country.name.common,
         icon: showFlagIcons
@@ -46,16 +56,51 @@ const CountryCodePicker = React.forwardRef<HTMLButtonElement, CountryCodePickerP
           )
         : defaultOptions
 
+    const selectedLabel = options.find((option) => option.value === internalValue)?.label ?? internalValue
+
+    const handleChange = useCallback(
+      (value: string | string[]) => {
+        if (Array.isArray(value)) {
+          console.warn('CountryCodePicker received array value, expected string')
+          return
+        }
+        setInternalValue(value)
+        onChange?.(value)
+      },
+      [onChange]
+    )
+
+    useEffect(() => {
+      if (value !== undefined) {
+        setInternalValue(value)
+      }
+    }, [value])
+
+    if (viewMode === 'edition') {
+      return (
+        <Select
+          ref={ref}
+          options={options}
+          selectionIcon="checkmark"
+          selectionIconPosition="right"
+          searchable={enableSearch}
+          value={internalValue}
+          onChange={handleChange}
+          placeholder={placeholder}
+          label={label}
+          required={required}
+          {...props}
+        />
+      )
+    }
+
     return (
-      <Select
-        ref={ref}
-        options={options}
-        selectionIcon="checkmark"
-        selectionIconPosition="right"
-        searchable={enableSearch}
-        onChange={onChange as ((value: string | string[]) => void) | undefined}
-        placeholder={placeholder}
-        {...props}
+      <CountryCodePickerDiff
+        value={selectedLabel}
+        label={label}
+        required={required}
+        viewMode={viewMode}
+        baseValue={baseValue}
       />
     )
   }

--- a/src/ui/components/data-entry/country-code-picker/country-code-picker.tsx
+++ b/src/ui/components/data-entry/country-code-picker/country-code-picker.tsx
@@ -57,6 +57,7 @@ const CountryCodePicker = React.forwardRef<HTMLButtonElement, CountryCodePickerP
         : defaultOptions
 
     const selectedLabel = options.find((option) => option.value === internalValue)?.label ?? internalValue
+    const baseLabel = options.find((option) => option.value === baseValue)?.label ?? baseValue
 
     const handleChange = useCallback(
       (value: string | string[]) => {
@@ -100,7 +101,7 @@ const CountryCodePicker = React.forwardRef<HTMLButtonElement, CountryCodePickerP
         label={label}
         required={required}
         viewMode={viewMode}
-        baseValue={baseValue}
+        baseValue={baseLabel}
       />
     )
   }

--- a/src/ui/components/data-entry/country-code-picker/types.ts
+++ b/src/ui/components/data-entry/country-code-picker/types.ts
@@ -1,20 +1,25 @@
 import type React from 'react'
-import type { InputBaseProps } from '../../../../scalars/components/types.js'
+import type { InputBaseProps, WithDifference } from '../../../../scalars/components/types.js'
+
+type CountryCodePickerWithDifference = Omit<WithDifference<string>, 'diffMode'>
 
 type CountryCodePickerBaseProps = Omit<
   React.ButtonHTMLAttributes<HTMLButtonElement>,
   keyof InputBaseProps<string> | 'onChange'
 >
 
-interface CountryCodePickerProps extends CountryCodePickerBaseProps, InputBaseProps<string> {
+interface CountryCodePickerProps
+  extends CountryCodePickerWithDifference,
+    CountryCodePickerBaseProps,
+    InputBaseProps<string> {
   onChange?: (value: string) => void
   placeholder?: string
   allowedCountries?: string[]
   excludedCountries?: string[]
   includeDependentAreas?: boolean
-  viewMode?: 'CodesOnly' | 'NamesOnly' | 'NamesAndCodes'
+  optionFormat?: 'CodesOnly' | 'NamesOnly' | 'NamesAndCodes'
   showFlagIcons?: boolean
   enableSearch?: boolean
 }
 
-export type { CountryCodePickerProps }
+export type { CountryCodePickerProps, CountryCodePickerWithDifference }

--- a/src/ui/components/data-entry/select/content.tsx
+++ b/src/ui/components/data-entry/select/content.tsx
@@ -37,8 +37,9 @@ export const Content: React.FC<ContentProps> = ({
   toggleOption,
   favoriteOptions = [],
 }) => {
-  const enabledOptions = options.filter((opt) => !opt.disabled)
-  const hasAnyIcon = options.some((opt) => opt.icon)
+  const allOptions = [...favoriteOptions, ...options]
+  const enabledOptions = allOptions.filter((opt) => !opt.disabled)
+  const hasAnyIcon = allOptions.some((opt) => opt.icon)
 
   const cmdkSearch = useCommandState((state) => state.search)
   // scroll to top when search change

--- a/src/ui/components/data-entry/select/select-diff.tsx
+++ b/src/ui/components/data-entry/select/select-diff.tsx
@@ -1,8 +1,9 @@
 import { FormGroup, FormLabel } from '../../../../scalars/components/fragments/index.js'
 import { SplittedInputDiff } from '../input/splitted-input-diff.js'
-import type { SelectProps, SelectWithDifference } from './types.js'
+import type { WithDifference } from '../../../../scalars/components/types.js'
+import type { SelectProps } from './types.js'
 
-interface SelectDiffProps extends SelectWithDifference {
+interface SelectDiffProps extends Omit<WithDifference<string>, 'diffMode'> {
   value: string
   label: SelectProps['label']
   required: SelectProps['required']

--- a/src/ui/components/data-entry/select/select.stories.tsx
+++ b/src/ui/components/data-entry/select/select.stories.tsx
@@ -93,11 +93,26 @@ const meta: Meta<typeof Select> = {
 
     options: {
       control: 'object',
-      description: 'Array of options to display in the select',
+      description:
+        'Array of options to display in the dropdown. These options will be displayed in the order they are provided.',
       table: {
         type: {
           summary:
-            'Array<{ value: string; label: string; icon?: IconName | React.ComponentType<{ className?: string }>; disabled?: boolean; className?: string }>',
+            'Array<{ value: string; label: string; icon?: IconName | React.ComponentType<{ className?: string }>; disabled?: boolean; }>',
+        },
+        defaultValue: { summary: '[]' },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+    },
+
+    favoriteOptions: {
+      control: 'object',
+      description:
+        'Array of favorite options to display in the dropdown. These options will be displayed at the top of the list.',
+      table: {
+        type: {
+          summary:
+            'Array<{ value: string; label: string; icon?: IconName | React.ComponentType<{ className?: string }>; disabled?: boolean; }>',
         },
         defaultValue: { summary: '[]' },
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
@@ -183,7 +198,14 @@ const meta: Meta<typeof Select> = {
     }),
 
     ...PrebuiltArgTypes.viewMode,
-    ...PrebuiltArgTypes.baseValue,
+    baseValue: {
+      control: 'object',
+      description: 'The base value of the select field',
+      table: {
+        type: { summary: 'string | string[]' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
   },
   args: {
     name: 'select',
@@ -409,5 +431,16 @@ export const WithCustomizedSelect: Story = {
     [&_.select\\_\\_item--selected]:[&>svg]:text-red-500
     [&_.select\\_\\_item--selected]:[&>svg]:size-8
   `,
+  },
+}
+
+export const WithDifferences: Story = {
+  args: {
+    label: 'Icon names comparison',
+    options: defaultOptions,
+    value: ['Globe', 'Settings'],
+    baseValue: ['Briefcase', 'Drive'],
+    multiple: true,
+    viewMode: 'mixed',
   },
 }

--- a/src/ui/components/data-entry/select/select.stories.tsx
+++ b/src/ui/components/data-entry/select/select.stories.tsx
@@ -183,16 +183,6 @@ const meta: Meta<typeof Select> = {
     }),
 
     ...PrebuiltArgTypes.viewMode,
-    diffMode: {
-      control: 'select',
-      description: 'The mode of the input field',
-      options: ['sentences'],
-      table: {
-        type: { summary: 'sentences' },
-        defaultValue: { summary: 'sentences' },
-        category: StorybookControlCategory.DIFF,
-      },
-    },
     ...PrebuiltArgTypes.baseValue,
   },
   args: {

--- a/src/ui/components/data-entry/select/select.test.tsx
+++ b/src/ui/components/data-entry/select/select.test.tsx
@@ -189,19 +189,21 @@ describe('Select Component', () => {
     })
 
     it('should render diff component when viewMode is addition', () => {
-      render(<Select name="select" options={defaultOptions} viewMode="addition" value="Option 1" />)
+      render(<Select name="select" options={defaultOptions} viewMode="addition" value="1" baseValue="2" />)
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
       expect(screen.getByText('Option 1')).toBeInTheDocument()
+      expect(screen.queryByText('Option 2')).not.toBeInTheDocument()
     })
 
     it('should render diff component when viewMode is removal', () => {
-      render(<Select name="select" options={defaultOptions} viewMode="removal" baseValue="Option 2" />)
+      render(<Select name="select" options={defaultOptions} viewMode="removal" value="1" baseValue="2" />)
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.queryByText('Option 1')).not.toBeInTheDocument()
       expect(screen.getByText('Option 2')).toBeInTheDocument()
     })
 
     it('should render diff component when viewMode is mixed', () => {
-      render(<Select name="select" options={defaultOptions} viewMode="mixed" value="Option 1" baseValue="Option 2" />)
+      render(<Select name="select" options={defaultOptions} viewMode="mixed" value="1" baseValue="2" />)
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
       expect(screen.getByText('Option 1')).toBeInTheDocument()
       expect(screen.getByText('Option 2')).toBeInTheDocument()
@@ -213,70 +215,40 @@ describe('Select Component', () => {
           name="select"
           options={defaultOptions}
           viewMode="mixed"
-          value="Option 1"
-          baseValue="Option 2"
-          required
+          value="1"
+          baseValue="2"
           label="Test Label"
+          required
         />
       )
-
-      // Verify label is rendered
-      expect(screen.getByText('Test Label')).toBeInTheDocument()
-
-      // Verify required indicator
-      expect(screen.getByText('*')).toBeInTheDocument()
-
-      // Verify the diff component is rendered (not the select)
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('*')).toBeInTheDocument()
       expect(screen.getByText('Option 1')).toBeInTheDocument()
       expect(screen.getByText('Option 2')).toBeInTheDocument()
     })
 
     it('should handle empty value in diff mode', () => {
-      const { container } = render(
-        <Select name="select" options={defaultOptions} viewMode="addition" value="" label="Test Label" />
-      )
-
-      // Verify that diff component is rendered instead of select
+      const { container } = render(<Select name="select" options={defaultOptions} viewMode="addition" value="" />)
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
-      expect(screen.getByText('Test Label')).toBeInTheDocument()
-
-      // Find all span elements and verify they are empty
       const diffSpans = container.querySelectorAll('span')
       diffSpans.forEach((span) => {
         expect(span).toHaveTextContent('')
       })
     })
 
-    it('should work with multiple selection in diff mode', () => {
+    it('should fallback to showing the raw value when no matching option is found', () => {
+      render(<Select name="select" options={defaultOptions} viewMode="mixed" value="11" baseValue="22" />)
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('11')).toBeInTheDocument()
+      expect(screen.getByText('22')).toBeInTheDocument()
+    })
+
+    it('should handle the multiple prop in diff mode', () => {
       render(
         <Select name="select" options={defaultOptions} viewMode="addition" value={['Option 1', 'Option 2']} multiple />
       )
-
-      // Should show both selected options
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
       expect(screen.getByText('Option 1, Option 2')).toBeInTheDocument()
-    })
-
-    it('should maintain all existing functionality in edition mode with new props present', async () => {
-      const user = userEvent.setup()
-      const onChange = vi.fn()
-
-      render(
-        <Select
-          name="select"
-          options={defaultOptions}
-          viewMode="edition"
-          baseValue="Option 2"
-          searchable
-          onChange={onChange}
-        />
-      )
-
-      // Should still work as a normal select
-      const select = screen.getByRole('combobox')
-      await user.click(select)
-      await user.click(screen.getByText('Option 1'))
-      expect(onChange).toHaveBeenCalledWith('1')
     })
   })
 })

--- a/src/ui/components/data-entry/select/select.tsx
+++ b/src/ui/components/data-entry/select/select.tsx
@@ -13,19 +13,6 @@ import { SelectedContent } from './selected-content.js'
 import { useSelect } from './use-select.js'
 import type { SelectProps } from './types.js'
 
-const processValue = (
-  currentValue: string | string[] | undefined,
-  currentDefaultValue: string | string[] | undefined
-): string => {
-  const displayValue = currentValue ?? currentDefaultValue ?? ''
-
-  if (Array.isArray(displayValue)) {
-    return displayValue.join(', ')
-  }
-
-  return displayValue
-}
-
 const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
   (
     {
@@ -63,7 +50,6 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
 
       // diff props
       viewMode = 'edition',
-      diffMode,
       baseValue,
       ...props
     },
@@ -207,11 +193,10 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
 
     return (
       <SelectDiff
-        value={processValue(value, defaultValue)}
+        value={selectedValues.join(', ')}
         label={label}
         required={required}
         viewMode={viewMode}
-        diffMode={diffMode}
         baseValue={baseValue}
       />
     )

--- a/src/ui/components/data-entry/select/select.tsx
+++ b/src/ui/components/data-entry/select/select.tsx
@@ -58,9 +58,10 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
     const prefix = useId()
     const id = propId ?? `${prefix}-select`
 
+    const allOptions = [...favoriteOptions, ...options]
     const { selectedValues, isPopoverOpen, commandListRef, toggleOption, handleClear, toggleAll, handleOpenChange } =
       useSelect({
-        options,
+        options: allOptions,
         multiple,
         defaultValue,
         value,
@@ -77,6 +78,17 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       },
       [onBlur, isPopoverOpen]
     )
+
+    const selectedLabels = selectedValues
+      .map((val) => allOptions.find((opt) => opt.value === val)?.label ?? val)
+      .join(', ')
+
+    const baseLabels =
+      baseValue !== undefined && baseValue !== ''
+        ? (Array.isArray(baseValue) ? baseValue : [baseValue])
+            .map((val) => allOptions.find((opt) => opt.value === val)?.label ?? val)
+            .join(', ')
+        : baseValue
 
     if (viewMode === 'edition') {
       return (
@@ -146,7 +158,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
               >
                 <SelectedContent
                   selectedValues={selectedValues}
-                  options={[...favoriteOptions, ...options]}
+                  options={allOptions}
                   multiple={multiple}
                   searchable={searchable}
                   placeholder={placeholder}
@@ -165,7 +177,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
               <Command
                 defaultValue={
                   !multiple && selectedValues[0]
-                    ? options.find((opt) => opt.value === selectedValues[0])?.label
+                    ? allOptions.find((opt) => opt.value === selectedValues[0])?.label
                     : undefined
                 }
               >
@@ -192,13 +204,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
     }
 
     return (
-      <SelectDiff
-        value={selectedValues.join(', ')}
-        label={label}
-        required={required}
-        viewMode={viewMode}
-        baseValue={baseValue}
-      />
+      <SelectDiff value={selectedLabels} label={label} required={required} viewMode={viewMode} baseValue={baseLabels} />
     )
   }
 )

--- a/src/ui/components/data-entry/select/types.ts
+++ b/src/ui/components/data-entry/select/types.ts
@@ -1,10 +1,8 @@
 import type { IconName } from '../../../components/icon/index.js'
-import type { DiffMode, InputBaseProps, WithDifference } from '../../../../scalars/components/types.js'
+import type { InputBaseProps, WithDifference } from '../../../../scalars/components/types.js'
 import type React from 'react'
 
-interface SelectWithDifference extends Omit<WithDifference<string>, 'diffMode'> {
-  diffMode?: Extract<DiffMode, 'sentences'>
-}
+type SelectWithDifference = Omit<WithDifference<string>, 'diffMode'>
 
 interface SelectOption {
   icon?: IconName | React.ComponentType<{ className?: string }>

--- a/src/ui/components/data-entry/select/types.ts
+++ b/src/ui/components/data-entry/select/types.ts
@@ -2,7 +2,7 @@ import type { IconName } from '../../../components/icon/index.js'
 import type { InputBaseProps, WithDifference } from '../../../../scalars/components/types.js'
 import type React from 'react'
 
-type SelectWithDifference = Omit<WithDifference<string>, 'diffMode'>
+type SelectWithDifference = Omit<WithDifference<string | string[]>, 'diffMode'>
 
 interface SelectOption {
   icon?: IconName | React.ComponentType<{ className?: string }>
@@ -42,4 +42,4 @@ type SelectProps = Omit<
     contentClassName?: string
   }
 
-export type { SelectBaseProps, SelectOption, SelectProps, SelectWithDifference }
+export type { SelectBaseProps, SelectOption, SelectProps }


### PR DESCRIPTION
## Ticket
https://trello.com/c/F6f4scJh/1032-create-a-read-only-diff-status-for-the-countrycode-component

## Description
- Should fix diff status in Select component.
- Should add the necessary props and types to display the new diff status in CountryCodePicker & CountryCodeFied.
- Should the new status allow to see the diff given the additions and removals.