### PR TITLE
feat(scalars & ui): add diff status to CurrencyCodePicker & CurrencyCodeField + minor fixes

### DIFF
--- a/src/scalars/components/amount-field/amount-field.stories.tsx
+++ b/src/scalars/components/amount-field/amount-field.stories.tsx
@@ -187,7 +187,7 @@ const meta = {
 } satisfies Meta<typeof AmountField>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof AmountField>
 
 export const Default: Story = {
   args: {

--- a/src/scalars/components/boolean-field/boolean-field.stories.tsx
+++ b/src/scalars/components/boolean-field/boolean-field.stories.tsx
@@ -85,7 +85,7 @@ const meta = {
 } satisfies Meta<typeof BooleanField>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof BooleanField>
 
 export const Checkbox: Story = {
   args: {

--- a/src/scalars/components/country-code-field/country-code-field.stories.tsx
+++ b/src/scalars/components/country-code-field/country-code-field.stories.tsx
@@ -93,7 +93,7 @@ const meta: Meta<typeof CountryCodeField> = {
 } satisfies Meta<typeof CountryCodeField>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof CountryCodeField>
 
 export const Default: Story = {
   args: {
@@ -169,5 +169,32 @@ export const WithDependentAreas: Story = {
     label: 'Country',
     description: 'Shows dependent areas',
     includeDependentAreas: true,
+  },
+}
+
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'Country addition',
+    value: 'FR',
+    baseValue: 'US',
+    viewMode: 'addition',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'Country removal',
+    value: 'FR',
+    baseValue: 'US',
+    viewMode: 'removal',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'Country mixed',
+    value: 'FR',
+    baseValue: 'US',
+    viewMode: 'mixed',
   },
 }

--- a/src/scalars/components/currency-code-field/__snapshots__/currency-code-field.test.tsx.snap
+++ b/src/scalars/components/currency-code-field/__snapshots__/currency-code-field.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`CurrencyCodeField > should match snapshot 1`] = `
             class="max-w-full truncate text-gray-900 dark:text-gray-50 flex items-center gap-2"
           >
             <div
-              class="flex items-center gap-2"
+              class="flex items-center gap-2 truncate"
             >
               <span
                 class="truncate text-[14px] font-normal leading-5"

--- a/src/scalars/components/currency-code-field/__snapshots__/currency-code-field.test.tsx.snap
+++ b/src/scalars/components/currency-code-field/__snapshots__/currency-code-field.test.tsx.snap
@@ -9,70 +9,66 @@ exports[`CurrencyCodeField > should match snapshot 1`] = `
     <div
       class="flex flex-col gap-2"
     >
-      <div
-        class="flex flex-col gap-2"
+      <label
+        class="inline-flex items-center text-sm font-medium leading-4 text-gray-900 dark:text-gray-50 mb-[3px]"
+        for=":r1:-select"
       >
-        <label
-          class="inline-flex items-center text-sm font-medium leading-4 text-gray-900 dark:text-gray-50 mb-[3px]"
-          for=":r1:-select"
-        >
-          Currency
-        </label>
-        <button
-          aria-controls="radix-:r2:"
-          aria-expanded="false"
-          aria-haspopup="dialog"
-          aria-invalid="false"
-          class="gap-2 whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 flex h-9 w-full items-center justify-between px-3 py-2 dark:border-charcoal-700 dark:bg-charcoal-900 rounded-md border border-gray-300 bg-white hover:border-gray-300 hover:bg-gray-100 dark:hover:border-charcoal-700 dark:hover:bg-charcoal-800 dark:focus:ring-charcoal-300 focus:outline-none focus:ring-1 focus:ring-gray-900 focus:ring-offset-0 dark:focus-visible:ring-charcoal-300 focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 select"
-          data-state="closed"
-          id=":r1:-select"
-          name="currency"
-          role="combobox"
-          type="button"
+        Currency
+      </label>
+      <button
+        aria-controls="radix-:r2:"
+        aria-expanded="false"
+        aria-haspopup="dialog"
+        aria-invalid="false"
+        class="gap-2 whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 flex h-9 w-full items-center justify-between px-3 py-2 dark:border-charcoal-700 dark:bg-charcoal-900 rounded-md border border-gray-300 bg-white hover:border-gray-300 hover:bg-gray-100 dark:hover:border-charcoal-700 dark:hover:bg-charcoal-800 dark:focus:ring-charcoal-300 focus:outline-none focus:ring-1 focus:ring-gray-900 focus:ring-offset-0 dark:focus-visible:ring-charcoal-300 focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 select"
+        data-state="closed"
+        id=":r1:-select"
+        name="currency"
+        role="combobox"
+        type="button"
+      >
+        <div
+          class="flex w-full items-center justify-between gap-2 select__list-item--selected"
         >
           <div
-            class="flex w-full items-center justify-between gap-2 select__list-item--selected"
+            class="max-w-full truncate text-gray-900 dark:text-gray-50 flex items-center gap-2"
           >
             <div
-              class="max-w-full truncate text-gray-900 dark:text-gray-50 flex items-center gap-2"
+              class="flex items-center gap-2"
             >
-              <div
-                class="flex items-center gap-2"
+              <span
+                class="truncate text-[14px] font-normal leading-5"
               >
-                <span
-                  class="truncate text-[14px] font-normal leading-5"
-                >
-                  USD ($)
-                </span>
-              </div>
-            </div>
-            <div
-              class="flex items-center justify-between gap-2"
-            >
-              <svg
-                class="cursor-pointer text-gray-700 dark:text-gray-400"
-                data-testid="icon-fallback"
-                fill="none"
-                stroke="currentcolor"
-                style="width: 16px; height: 16px;"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M6 9L12 15L18 9"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
+                USD ($)
+              </span>
             </div>
           </div>
-        </button>
-        <p
-          class="font-sans text-sm font-normal leading-5 text-gray-600 dark:text-gray-500"
-        >
-          Select a currency
-        </p>
-      </div>
+          <div
+            class="flex items-center justify-between gap-2"
+          >
+            <svg
+              class="cursor-pointer text-gray-700 dark:text-gray-400"
+              data-testid="icon-fallback"
+              fill="none"
+              stroke="currentcolor"
+              style="width: 16px; height: 16px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6 9L12 15L18 9"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </div>
+        </div>
+      </button>
+      <p
+        class="font-sans text-sm font-normal leading-5 text-gray-600 dark:text-gray-500"
+      >
+        Select a currency
+      </p>
     </div>
   </form>
 </div>

--- a/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
+++ b/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
@@ -90,13 +90,13 @@ type Story = StoryObj<typeof CurrencyCodeField>
 
 export const Default: Story = {
   args: {
-    label: 'Currency code',
+    label: 'Currency',
   },
 }
 
 export const Disabled: Story = {
   args: {
-    label: 'Currency code',
+    label: 'Currency',
     value: 'EUR',
     disabled: true,
     allowedTypes: 'Fiat',
@@ -105,7 +105,7 @@ export const Disabled: Story = {
 
 export const WithFavorites: Story = {
   args: {
-    label: 'Currency code',
+    label: 'Currency',
     currencies: [
       {
         ticker: 'BTC',

--- a/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
+++ b/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
@@ -86,17 +86,17 @@ const meta: Meta<typeof CurrencyCodeField> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof CurrencyCodeField>
 
 export const Default: Story = {
   args: {
-    label: 'Currency',
+    label: 'Currency code',
   },
 }
 
 export const Disabled: Story = {
   args: {
-    label: 'Currency',
+    label: 'Currency code',
     value: 'EUR',
     disabled: true,
     allowedTypes: 'Fiat',
@@ -105,7 +105,7 @@ export const Disabled: Story = {
 
 export const WithFavorites: Story = {
   args: {
-    label: 'Currency',
+    label: 'Currency code',
     currencies: [
       {
         ticker: 'BTC',
@@ -132,5 +132,32 @@ export const WithFavorites: Story = {
       },
     ],
     favoriteCurrencies: ['BTC', 'ETH'],
+  },
+}
+
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'Currency addition',
+    value: 'DAI',
+    baseValue: 'ETH',
+    viewMode: 'addition',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'Currency removal',
+    value: 'DAI',
+    baseValue: 'ETH',
+    viewMode: 'removal',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'Currency mixed',
+    value: 'DAI',
+    baseValue: 'ETH',
+    viewMode: 'mixed',
   },
 }

--- a/src/scalars/components/date-picker-field/date-picker-field.stories.tsx
+++ b/src/scalars/components/date-picker-field/date-picker-field.stories.tsx
@@ -128,7 +128,7 @@ const meta: Meta<typeof DatePickerField> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof DatePickerField>
 
 export const Default: Story = {
   args: {

--- a/src/scalars/components/date-time-picker-field/date-time-picker-field.stories.tsx
+++ b/src/scalars/components/date-time-picker-field/date-time-picker-field.stories.tsx
@@ -180,7 +180,7 @@ const meta: Meta<typeof DateTimePickerField> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof DateTimePickerField>
 
 export const DateTimePicker: Story = {
   args: {

--- a/src/scalars/components/enum-field/enum-field.stories.tsx
+++ b/src/scalars/components/enum-field/enum-field.stories.tsx
@@ -132,8 +132,6 @@ const meta: Meta<typeof EnumField> = {
   },
   args: {
     name: 'enum-field',
-    errors: [],
-    warnings: [],
   },
 } satisfies Meta<typeof EnumField>
 
@@ -343,9 +341,34 @@ export const WithCustomStylesRadioGroup: Story = {
   },
 }
 
-export const SelectWithDifferences: Story = {
+// Differences examples
+export const WithDifferencesAddition: Story = {
   args: {
-    label: 'Icon names comparison',
+    label: 'Icon names addition',
+    variant: 'Select',
+    options: defaultOptions,
+    value: ['Globe', 'Settings'],
+    baseValue: ['Briefcase', 'Drive'],
+    multiple: true,
+    viewMode: 'addition',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'Icon names removal',
+    variant: 'Select',
+    options: defaultOptions,
+    value: ['Globe', 'Settings'],
+    baseValue: ['Briefcase', 'Drive'],
+    multiple: true,
+    viewMode: 'removal',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'Icon names mixed',
     variant: 'Select',
     options: defaultOptions,
     value: ['Globe', 'Settings'],

--- a/src/scalars/components/examples/enum-field-example/enum-field-example.stories.tsx
+++ b/src/scalars/components/examples/enum-field-example/enum-field-example.stories.tsx
@@ -74,7 +74,7 @@ function EnumFieldExample() {
 
 export default meta
 
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof EnumFieldExample>
 
 export const Default: Story = {
   args: {},

--- a/src/scalars/components/examples/multiple-fields-with-complex-layout/multiple-fields-with-complex-layout.stories.tsx
+++ b/src/scalars/components/examples/multiple-fields-with-complex-layout/multiple-fields-with-complex-layout.stories.tsx
@@ -138,7 +138,7 @@ function MultipleFieldsWithComplexLayout() {
 } satisfies Meta<typeof MultipleFieldsWithComplexLayout>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof MultipleFieldsWithComplexLayout>
 
 export const Default: Story = {
   args: {},

--- a/src/scalars/components/examples/reset-button/reset-button.stories.tsx
+++ b/src/scalars/components/examples/reset-button/reset-button.stories.tsx
@@ -45,7 +45,7 @@ const FormWithResetButton = () => {
 } satisfies Meta<typeof FormWithResetButton>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof FormWithResetButton>
 
 export const Default: Story = {
   args: {},

--- a/src/scalars/components/examples/reset-on-successful-submit/reset-on-successful-submit.stories.tsx
+++ b/src/scalars/components/examples/reset-on-successful-submit/reset-on-successful-submit.stories.tsx
@@ -46,6 +46,6 @@ const FormWithResetOnSuccessfulSubmit = () => {
 } satisfies Meta<typeof FormWithResetOnSuccessfulSubmit>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof FormWithResetOnSuccessfulSubmit>
 
 export const Default: Story = {}

--- a/src/scalars/components/examples/submit-changes-only/submit-changes-only.stories.tsx
+++ b/src/scalars/components/examples/submit-changes-only/submit-changes-only.stories.tsx
@@ -18,6 +18,6 @@ const meta = {
 } satisfies Meta<typeof SubmitChangesOnly>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof SubmitChangesOnly>
 
 export const Default: Story = {}

--- a/src/scalars/components/fragments/character-counter/character-counter.stories.tsx
+++ b/src/scalars/components/fragments/character-counter/character-counter.stories.tsx
@@ -24,7 +24,7 @@ const meta = {
 } satisfies Meta<typeof CharacterCounter>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof CharacterCounter>
 
 export const Default: Story = {
   args: {

--- a/src/scalars/components/fragments/form-description/form-description.stories.tsx
+++ b/src/scalars/components/fragments/form-description/form-description.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
 } satisfies Meta<typeof FormDescription>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof FormDescription>
 
 export const Default: Story = {
   args: {

--- a/src/scalars/components/fragments/form-label/form-label.stories.tsx
+++ b/src/scalars/components/fragments/form-label/form-label.stories.tsx
@@ -45,7 +45,7 @@ const meta: Meta<typeof FormLabel> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof FormLabel>
 
 export const Default: Story = {
   args: {

--- a/src/scalars/components/fragments/form-message/form-message.stories.tsx
+++ b/src/scalars/components/fragments/form-message/form-message.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta<typeof FormMessage> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof FormMessage>
 
 export const Info: Story = {
   args: {

--- a/src/scalars/components/number-field/number-field.stories.tsx
+++ b/src/scalars/components/number-field/number-field.stories.tsx
@@ -85,13 +85,11 @@ const meta = {
   },
   args: {
     name: 'number-field',
-    errors: [],
-    warnings: [],
   },
 } satisfies Meta<typeof NumberField>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof NumberField>
 
 export const Default: Story = {
   args: {

--- a/src/scalars/components/string-field/string-field.stories.tsx
+++ b/src/scalars/components/string-field/string-field.stories.tsx
@@ -58,7 +58,7 @@ const meta: Meta<typeof StringField> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof StringField>
 
 export const Default: Story = {
   args: {

--- a/src/scalars/components/time-picker-field/time-picker-field.stories.tsx
+++ b/src/scalars/components/time-picker-field/time-picker-field.stories.tsx
@@ -109,7 +109,7 @@ const meta: Meta<typeof TimePickerField> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof TimePickerField>
 
 export const Default: Story = {
   args: {

--- a/src/scalars/components/url-field/url-field.stories.tsx
+++ b/src/scalars/components/url-field/url-field.stories.tsx
@@ -67,7 +67,7 @@ const meta: Meta<typeof UrlField> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof UrlField>
 
 export const Default: Story = {
   args: {

--- a/src/ui/components/data-entry/amount-input/amount-input.stories.tsx
+++ b/src/ui/components/data-entry/amount-input/amount-input.stories.tsx
@@ -203,7 +203,7 @@ const meta = {
 } satisfies Meta<typeof AmountInput>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof AmountInput>
 
 export const Default: Story = {
   args: {

--- a/src/ui/components/data-entry/amount-input/amount-input.tsx
+++ b/src/ui/components/data-entry/amount-input/amount-input.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../../scalars/components/fragments/index.js'
 import { cn } from '../../../../scalars/lib/utils.js'
 import { type Currency, CurrencyCodePicker } from '../currency-code-picker/index.js'
-import type { SelectFieldProps } from '../../../../scalars/components/fragments/select-field/index.js'
+import type { SelectProps } from '../select/index.js'
 import type { Amount, AmountInputPropsGeneric } from './types.js'
 import { useAmountInput } from './use-amount-input.js'
 import { NumberInput } from '../number-input/index.js'
@@ -17,7 +17,14 @@ type AdditionalProps = Omit<InputNumberProps, 'onChange' | 'onBlur' | 'precision
   className?: string
   name: string
   numberProps?: Omit<NumberFieldProps, 'name'>
-  selectProps?: Omit<SelectFieldProps, 'placeholder' | 'selectionIcon' | 'onBlur'>
+  selectProps?: Omit<
+    SelectProps,
+    'placeholder' | 'selectionIcon' | 'onBlur' | 'baseValue' | 'defaultValue' | 'value'
+  > & {
+    baseValue?: string
+    defaultValue?: string
+    value?: string
+  }
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
   currencyPosition?: 'left' | 'right'
@@ -131,6 +138,7 @@ const AmountInputController = forwardRef<HTMLInputElement, AmountInputProps>(
               contentClassName="[&]:!w-[120px]"
               disabled={disabled}
               currencies={options}
+              value={valueSelect}
               onChange={handleOnChangeSelect}
               placeholder={placeholderSelect}
               includeCurrencySymbols={includeCurrencySymbols}

--- a/src/ui/components/data-entry/amount-input/use-amount-input.tsx
+++ b/src/ui/components/data-entry/amount-input/use-amount-input.tsx
@@ -216,7 +216,7 @@ export const useAmountInput = ({
     }
   }
   // Handle the change of the select
-  const handleOnChangeSelect = (e: string | string[]) => {
+  const handleOnChangeSelect = (e: string) => {
     let newValue: AmountFiat | AmountCrypto | AmountCurrency | Amount = {} as
       | AmountFiat
       | AmountCrypto

--- a/src/ui/components/data-entry/amount-input/utils.ts
+++ b/src/ui/components/data-entry/amount-input/utils.ts
@@ -103,7 +103,6 @@ export const isValidUnit = (type: AmountInputPropsGeneric['type'], value: Amount
     return units.some((u) => u.ticker === value.unit)
   }
   if (type === 'AmountCurrency' && typeof value === 'object') {
-    console.log('ebtre')
     return units.some((u) => u.ticker === value.unit)
   }
   if (type === 'AmountCrypto' && typeof value === 'object') {

--- a/src/ui/components/data-entry/checkbox/checkbox.stories.tsx
+++ b/src/ui/components/data-entry/checkbox/checkbox.stories.tsx
@@ -75,7 +75,7 @@ const meta = {
 } satisfies Meta<typeof Checkbox>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof Checkbox>
 
 export const Default: Story = {
   args: {

--- a/src/ui/components/data-entry/country-code-picker/country-code-picker.stories.tsx
+++ b/src/ui/components/data-entry/country-code-picker/country-code-picker.stories.tsx
@@ -115,7 +115,7 @@ const meta: Meta<typeof CountryCodePicker> = {
 } satisfies Meta<typeof CountryCodePicker>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof CountryCodePicker>
 
 export const Default: Story = {
   args: {
@@ -191,5 +191,32 @@ export const WithDependentAreas: Story = {
     label: 'Country',
     description: 'Shows dependent areas',
     includeDependentAreas: true,
+  },
+}
+
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'Country addition',
+    value: 'FR',
+    baseValue: 'US',
+    viewMode: 'addition',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'Country removal',
+    value: 'FR',
+    baseValue: 'US',
+    viewMode: 'removal',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'Country mixed',
+    value: 'FR',
+    baseValue: 'US',
+    viewMode: 'mixed',
   },
 }

--- a/src/ui/components/data-entry/country-code-picker/country-code-picker.tsx
+++ b/src/ui/components/data-entry/country-code-picker/country-code-picker.tsx
@@ -20,7 +20,6 @@ const CountryCodePicker = React.forwardRef<HTMLButtonElement, CountryCodePickerP
       optionFormat = 'NamesOnly',
       showFlagIcons = true,
       enableSearch,
-      // diff props
       viewMode = 'edition',
       baseValue,
       ...props

--- a/src/ui/components/data-entry/currency-code-picker/__snapshots__/currency-code-picker.test.tsx.snap
+++ b/src/ui/components/data-entry/currency-code-picker/__snapshots__/currency-code-picker.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`CurrencyCodePicker > should match snapshot 1`] = `
           class="max-w-full truncate text-gray-900 dark:text-gray-50 flex items-center gap-2"
         >
           <div
-            class="flex items-center gap-2"
+            class="flex items-center gap-2 truncate"
           >
             <span
               class="truncate text-[14px] font-normal leading-5"

--- a/src/ui/components/data-entry/currency-code-picker/__snapshots__/currency-code-picker.test.tsx.snap
+++ b/src/ui/components/data-entry/currency-code-picker/__snapshots__/currency-code-picker.test.tsx.snap
@@ -5,70 +5,66 @@ exports[`CurrencyCodePicker > should match snapshot 1`] = `
   <div
     class="flex flex-col gap-2"
   >
-    <div
-      class="flex flex-col gap-2"
+    <label
+      class="inline-flex items-center text-sm font-medium leading-4 text-gray-900 dark:text-gray-50 mb-[3px]"
+      for=":r0:-select"
     >
-      <label
-        class="inline-flex items-center text-sm font-medium leading-4 text-gray-900 dark:text-gray-50 mb-[3px]"
-        for=":r0:-select"
-      >
-        Currency
-      </label>
-      <button
-        aria-controls="radix-:r1:"
-        aria-expanded="false"
-        aria-haspopup="dialog"
-        aria-invalid="false"
-        class="gap-2 whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 flex h-9 w-full items-center justify-between px-3 py-2 dark:border-charcoal-700 dark:bg-charcoal-900 rounded-md border border-gray-300 bg-white hover:border-gray-300 hover:bg-gray-100 dark:hover:border-charcoal-700 dark:hover:bg-charcoal-800 dark:focus:ring-charcoal-300 focus:outline-none focus:ring-1 focus:ring-gray-900 focus:ring-offset-0 dark:focus-visible:ring-charcoal-300 focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 select"
-        data-state="closed"
-        id=":r0:-select"
-        name="currency"
-        role="combobox"
-        type="button"
+      Currency
+    </label>
+    <button
+      aria-controls="radix-:r1:"
+      aria-expanded="false"
+      aria-haspopup="dialog"
+      aria-invalid="false"
+      class="gap-2 whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 flex h-9 w-full items-center justify-between px-3 py-2 dark:border-charcoal-700 dark:bg-charcoal-900 rounded-md border border-gray-300 bg-white hover:border-gray-300 hover:bg-gray-100 dark:hover:border-charcoal-700 dark:hover:bg-charcoal-800 dark:focus:ring-charcoal-300 focus:outline-none focus:ring-1 focus:ring-gray-900 focus:ring-offset-0 dark:focus-visible:ring-charcoal-300 focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 select"
+      data-state="closed"
+      id=":r0:-select"
+      name="currency"
+      role="combobox"
+      type="button"
+    >
+      <div
+        class="flex w-full items-center justify-between gap-2 select__list-item--selected"
       >
         <div
-          class="flex w-full items-center justify-between gap-2 select__list-item--selected"
+          class="max-w-full truncate text-gray-900 dark:text-gray-50 flex items-center gap-2"
         >
           <div
-            class="max-w-full truncate text-gray-900 dark:text-gray-50 flex items-center gap-2"
+            class="flex items-center gap-2"
           >
-            <div
-              class="flex items-center gap-2"
+            <span
+              class="truncate text-[14px] font-normal leading-5"
             >
-              <span
-                class="truncate text-[14px] font-normal leading-5"
-              >
-                USD ($)
-              </span>
-            </div>
-          </div>
-          <div
-            class="flex items-center justify-between gap-2"
-          >
-            <svg
-              class="cursor-pointer text-gray-700 dark:text-gray-400"
-              data-testid="icon-fallback"
-              fill="none"
-              stroke="currentcolor"
-              style="width: 16px; height: 16px;"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M6 9L12 15L18 9"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
+              USD ($)
+            </span>
           </div>
         </div>
-      </button>
-      <p
-        class="font-sans text-sm font-normal leading-5 text-gray-600 dark:text-gray-500"
-      >
-        Select a currency
-      </p>
-    </div>
+        <div
+          class="flex items-center justify-between gap-2"
+        >
+          <svg
+            class="cursor-pointer text-gray-700 dark:text-gray-400"
+            data-testid="icon-fallback"
+            fill="none"
+            stroke="currentcolor"
+            style="width: 16px; height: 16px;"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 9L12 15L18 9"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </div>
+      </div>
+    </button>
+    <p
+      class="font-sans text-sm font-normal leading-5 text-gray-600 dark:text-gray-500"
+    >
+      Select a currency
+    </p>
   </div>
 </div>
 `;

--- a/src/ui/components/data-entry/currency-code-picker/currency-code-picker-diff.tsx
+++ b/src/ui/components/data-entry/currency-code-picker/currency-code-picker-diff.tsx
@@ -1,0 +1,30 @@
+import { FormGroup, FormLabel } from '../../../../scalars/components/fragments/index.js'
+import { SplittedInputDiff } from '../input/splitted-input-diff.js'
+import type { CurrencyCodePickerProps, CurrencyCodePickerWithDifference } from './types.js'
+
+interface CurrencyCodePickerDiffProps extends CurrencyCodePickerWithDifference {
+  value: string
+  label: CurrencyCodePickerProps['label']
+  required: CurrencyCodePickerProps['required']
+}
+
+const CurrencyCodePickerDiff = ({
+  value = '',
+  label,
+  required,
+  viewMode,
+  baseValue = '',
+}: CurrencyCodePickerDiffProps) => {
+  return (
+    <FormGroup>
+      {label && (
+        <FormLabel disabled={true} required={required}>
+          {label}
+        </FormLabel>
+      )}
+      <SplittedInputDiff baseValue={baseValue} value={value} viewMode={viewMode} diffMode="sentences" />
+    </FormGroup>
+  )
+}
+
+export { CurrencyCodePickerDiff }

--- a/src/ui/components/data-entry/currency-code-picker/currency-code-picker.stories.tsx
+++ b/src/ui/components/data-entry/currency-code-picker/currency-code-picker.stories.tsx
@@ -128,7 +128,7 @@ const meta: Meta<typeof CurrencyCodePicker> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof CurrencyCodePicker>
 
 export const Default: Story = {
   args: {
@@ -174,5 +174,32 @@ export const WithFavorites: Story = {
       },
     ],
     favoriteCurrencies: ['BTC', 'ETH'],
+  },
+}
+
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'Currency addition',
+    value: 'DAI',
+    baseValue: 'ETH',
+    viewMode: 'addition',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'Currency removal',
+    value: 'DAI',
+    baseValue: 'ETH',
+    viewMode: 'removal',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'Currency mixed',
+    value: 'DAI',
+    baseValue: 'ETH',
+    viewMode: 'mixed',
   },
 }

--- a/src/ui/components/data-entry/currency-code-picker/currency-code-picker.test.tsx
+++ b/src/ui/components/data-entry/currency-code-picker/currency-code-picker.test.tsx
@@ -117,4 +117,113 @@ describe('CurrencyCodePicker', () => {
     expect(screen.queryByText('EUR (€)')).not.toBeInTheDocument()
     expect(screen.queryByText('GBP (£)')).not.toBeInTheDocument()
   })
+
+  // Tests for viewMode and diffs functionality
+  describe('viewMode and diffs', () => {
+    it('should render in edition mode by default', () => {
+      render(<CurrencyCodePicker name="currency" label="Currency" />)
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
+    })
+
+    it('should render in edition mode when viewMode is explicitly set to edition', () => {
+      render(<CurrencyCodePicker name="currency" label="Currency" viewMode="edition" />)
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is addition', () => {
+      render(<CurrencyCodePicker name="currency" label="Currency" viewMode="addition" value="USDC" baseValue="ETH" />)
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('USDC (USDC)')).toBeInTheDocument()
+      expect(screen.queryByText('ETH (ETH)')).not.toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is removal', () => {
+      render(<CurrencyCodePicker name="currency" label="Currency" viewMode="removal" value="USDC" baseValue="ETH" />)
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('ETH (ETH)')).toBeInTheDocument()
+      expect(screen.queryByText('USDC (USDC)')).not.toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is mixed', () => {
+      render(<CurrencyCodePicker name="currency" label="Currency" viewMode="mixed" value="ETH" baseValue="USDC" />)
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('ETH (ETH)')).toBeInTheDocument()
+      expect(screen.getByText('USDC (USDC)')).toBeInTheDocument()
+    })
+
+    it('should pass correct props to CurrencyCodePickerDiff component', () => {
+      render(
+        <CurrencyCodePicker name="currency" label="Currency" viewMode="mixed" value="USDC" baseValue="ETH" required />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('*')).toBeInTheDocument()
+      expect(screen.getByText('USDC (USDC)')).toBeInTheDocument()
+      expect(screen.getByText('ETH (ETH)')).toBeInTheDocument()
+    })
+
+    it('should handle empty value in diff mode', () => {
+      const { container } = render(<CurrencyCodePicker name="currency" label="Currency" viewMode="addition" value="" />)
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      const diffSpans = container.querySelectorAll('span')
+      diffSpans.forEach((span) => {
+        expect(span).toHaveTextContent('')
+      })
+    })
+
+    it('should fallback to showing the raw value when no matching option is found', () => {
+      render(<CurrencyCodePicker name="currency" label="Currency" viewMode="mixed" value="NEW" baseValue="OLD" />)
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('NEW')).toBeInTheDocument()
+      expect(screen.getByText('OLD')).toBeInTheDocument()
+    })
+
+    it('should respect includeCurrencySymbols in diff mode', () => {
+      render(
+        <CurrencyCodePicker
+          name="currency"
+          label="Currency"
+          viewMode="addition"
+          value="USD"
+          includeCurrencySymbols={false}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      // Should show just "USD" without symbol
+      expect(screen.getByText('USD')).toBeInTheDocument()
+      expect(screen.queryByText('USD ($)')).not.toBeInTheDocument()
+    })
+
+    it('should respect symbolPosition in diff mode', () => {
+      render(
+        <CurrencyCodePicker name="currency" label="Currency" viewMode="addition" value="EUR" symbolPosition="left" />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      // Should show "($) EUR" format with symbol on the left
+      expect(screen.getByText('(€) EUR')).toBeInTheDocument()
+      expect(screen.queryByText('EUR (€)')).not.toBeInTheDocument()
+    })
+
+    it('should work with allowedTypes in diff mode', () => {
+      render(
+        <CurrencyCodePicker name="currency" label="Currency" viewMode="addition" value="ETH" allowedTypes="Crypto" />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('ETH (ETH)')).toBeInTheDocument()
+      expect(screen.queryByText('USD ($)')).not.toBeInTheDocument()
+    })
+
+    it('should handle favoriteCurrencies in diff mode', () => {
+      render(
+        <CurrencyCodePicker
+          name="currency"
+          label="Currency"
+          viewMode="addition"
+          value="USD"
+          favoriteCurrencies={['USD']}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('USD ($)')).toBeInTheDocument()
+    })
+  })
 })

--- a/src/ui/components/data-entry/currency-code-picker/types.ts
+++ b/src/ui/components/data-entry/currency-code-picker/types.ts
@@ -1,6 +1,8 @@
 import type React from 'react'
 import type { IconName } from '../../icon/index.js'
-import type { InputBaseProps } from '../../../../scalars/components/types.js'
+import type { InputBaseProps, WithDifference } from '../../../../scalars/components/types.js'
+
+type CurrencyCodePickerWithDifference = Omit<WithDifference<string>, 'diffMode'>
 
 type AllowedTypes = 'Crypto' | 'Fiat' | 'Both'
 
@@ -14,13 +16,15 @@ interface Currency {
 
 type CurrencyCodePickerBaseProps = Omit<
   React.ButtonHTMLAttributes<HTMLButtonElement>,
-  keyof InputBaseProps<string | string[]> | 'onChange' | 'onBlur'
+  keyof InputBaseProps<string> | 'onChange'
 >
 
-interface CurrencyCodePickerProps extends CurrencyCodePickerBaseProps, InputBaseProps<string | string[]> {
+interface CurrencyCodePickerProps
+  extends CurrencyCodePickerWithDifference,
+    CurrencyCodePickerBaseProps,
+    InputBaseProps<string> {
   placeholder?: string
-  onChange?: (value: string | string[]) => void
-  onBlur?: () => void
+  onChange?: (value: string) => void
   currencies?: Currency[]
   includeCurrencySymbols?: boolean
   favoriteCurrencies?: string[]
@@ -31,4 +35,4 @@ interface CurrencyCodePickerProps extends CurrencyCodePickerBaseProps, InputBase
   allowedTypes?: AllowedTypes
 }
 
-export type { AllowedTypes, Currency, CurrencyCodePickerProps }
+export type { AllowedTypes, Currency, CurrencyCodePickerProps, CurrencyCodePickerWithDifference }

--- a/src/ui/components/data-entry/date-picker/date-picker.stories.tsx
+++ b/src/ui/components/data-entry/date-picker/date-picker.stories.tsx
@@ -200,7 +200,7 @@ const meta: Meta<typeof DatePicker> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof DatePicker>
 
 export const Default: Story = {
   args: {

--- a/src/ui/components/data-entry/date-time-picker/date-time-picker.stories.tsx
+++ b/src/ui/components/data-entry/date-time-picker/date-time-picker.stories.tsx
@@ -309,7 +309,7 @@ const meta: Meta<typeof DateTimePicker> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof DateTimePicker>
 
 export const Default: Story = {
   args: {

--- a/src/ui/components/data-entry/input/input.stories.tsx
+++ b/src/ui/components/data-entry/input/input.stories.tsx
@@ -32,7 +32,7 @@ const meta = {
 } satisfies Meta<typeof Input>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof Input>
 
 export const Default: Story = {
   args: {

--- a/src/ui/components/data-entry/number-input/number-input.stories.tsx
+++ b/src/ui/components/data-entry/number-input/number-input.stories.tsx
@@ -102,13 +102,11 @@ const meta = {
   },
   args: {
     name: 'number-field',
-    errors: [],
-    warnings: [],
   },
 } satisfies Meta<typeof NumberInput>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof NumberInput>
 
 export const Default: Story = {
   args: {

--- a/src/ui/components/data-entry/radio-group/radio-group.stories.tsx
+++ b/src/ui/components/data-entry/radio-group/radio-group.stories.tsx
@@ -128,8 +128,6 @@ const meta: Meta<typeof RadioGroup> = {
   },
   args: {
     name: 'radio-group',
-    errors: [],
-    warnings: [],
   },
 } satisfies Meta<typeof RadioGroup>
 

--- a/src/ui/components/data-entry/select/select.stories.tsx
+++ b/src/ui/components/data-entry/select/select.stories.tsx
@@ -209,8 +209,6 @@ const meta: Meta<typeof Select> = {
   },
   args: {
     name: 'select',
-    errors: [],
-    warnings: [],
   },
 } satisfies Meta<typeof Select>
 
@@ -434,9 +432,32 @@ export const WithCustomizedSelect: Story = {
   },
 }
 
-export const WithDifferences: Story = {
+// Differences examples
+export const WithDifferencesAddition: Story = {
   args: {
-    label: 'Icon names comparison',
+    label: 'Icon names addition',
+    options: defaultOptions,
+    value: ['Globe', 'Settings'],
+    baseValue: ['Briefcase', 'Drive'],
+    multiple: true,
+    viewMode: 'addition',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'Icon names removal',
+    options: defaultOptions,
+    value: ['Globe', 'Settings'],
+    baseValue: ['Briefcase', 'Drive'],
+    multiple: true,
+    viewMode: 'removal',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'Icon names mixed',
     options: defaultOptions,
     value: ['Globe', 'Settings'],
     baseValue: ['Briefcase', 'Drive'],

--- a/src/ui/components/data-entry/select/selected-content.tsx
+++ b/src/ui/components/data-entry/select/selected-content.tsx
@@ -29,9 +29,11 @@ export const SelectedContent: React.FC<SelectedContentProps> = ({
 
   if (selectedValues.length === 0) {
     return (
-      <div className={cn('mx-auto flex w-full items-center', placeholder ? 'justify-between' : 'justify-end')}>
+      <div className={cn('mx-auto flex w-full items-center', placeholder ? 'justify-between gap-2' : 'justify-end')}>
         {placeholder && (
-          <span className="text-[14px] font-normal leading-5 text-gray-600 dark:text-gray-500">{placeholder}</span>
+          <span className="text-[14px] font-normal leading-5 truncate text-gray-600 dark:text-gray-500">
+            {placeholder}
+          </span>
         )}
         {searchable ? (
           <Icon name="CaretSort" size={16} className="cursor-pointer text-gray-700 dark:text-gray-400" />
@@ -50,7 +52,7 @@ export const SelectedContent: React.FC<SelectedContentProps> = ({
         {selectedValues.map((value, index) => {
           const option = options.find((o) => o.value === value)
           return !multiple ? (
-            <div key={value} className={cn('flex items-center gap-2')}>
+            <div key={value} className={cn('flex items-center gap-2 truncate')}>
               {renderIcon(option?.icon)}
               <span className={cn('truncate text-[14px] font-normal leading-5')}>{option?.label}</span>
             </div>

--- a/src/ui/components/data-entry/select/use-select.ts
+++ b/src/ui/components/data-entry/select/use-select.ts
@@ -56,7 +56,7 @@ export function useSelect({ options = [], multiple = false, defaultValue, value,
       setSelectedValues(newValues)
       onChange?.(multiple ? newValues : (newValues[0] ?? ''))
     },
-    [multiple, selectedValues, options, onChange]
+    [multiple, selectedValues, onChange]
   )
 
   const handleClear = useCallback(() => {

--- a/src/ui/components/data-entry/text-input/text-input.stories.tsx
+++ b/src/ui/components/data-entry/text-input/text-input.stories.tsx
@@ -66,7 +66,7 @@ const meta = {
 } satisfies Meta<typeof TextInput>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof TextInput>
 
 export const Default: Story = {
   args: {

--- a/src/ui/components/data-entry/textarea/textarea.stories.tsx
+++ b/src/ui/components/data-entry/textarea/textarea.stories.tsx
@@ -77,7 +77,7 @@ const meta = {
 } satisfies Meta<typeof Textarea>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof Textarea>
 
 export const Default: Story = {
   args: {

--- a/src/ui/components/data-entry/time-picker/time-picker.stories.tsx
+++ b/src/ui/components/data-entry/time-picker/time-picker.stories.tsx
@@ -143,7 +143,7 @@ const meta: Meta<typeof TimePicker> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof TimePicker>
 
 export const Default: Story = {
   args: {

--- a/src/ui/components/data-entry/toggle/toggle.stories.tsx
+++ b/src/ui/components/data-entry/toggle/toggle.stories.tsx
@@ -71,7 +71,7 @@ const meta = {
 } satisfies Meta<typeof Toggle>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof Toggle>
 
 export const Default: Story = {
   args: {

--- a/src/ui/components/data-entry/url-input/url-input.stories.tsx
+++ b/src/ui/components/data-entry/url-input/url-input.stories.tsx
@@ -81,7 +81,7 @@ const meta: Meta<typeof UrlInput> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof UrlInput>
 
 export const Default: Story = {
   args: {

--- a/src/ui/components/dropdown/dropdown.stories.tsx
+++ b/src/ui/components/dropdown/dropdown.stories.tsx
@@ -190,7 +190,7 @@ const meta: Meta<typeof DropdownExample> = {
 } satisfies Meta<typeof DropdownExample>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof DropdownExample>
 export const Default: Story = {
   args: {
     label: 'Export as',

--- a/src/ui/components/icon/icon.stories.tsx
+++ b/src/ui/components/icon/icon.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
 } satisfies Meta<typeof Icon>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof Icon>
 
 export const AllIcons: Story = {
   args: {

--- a/src/ui/components/tooltip/tooltip.stories.tsx
+++ b/src/ui/components/tooltip/tooltip.stories.tsx
@@ -64,7 +64,7 @@ const meta: Meta<typeof Tooltip> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof Tooltip>
 
 export const Default: Story = {
   args: {


### PR DESCRIPTION
## Ticket
https://trello.com/c/NrscowFN/1031-create-a-read-only-diff-status-for-the-currency-component

## Description
- Should fix minor issues in stories.
- Should fix some types in Select based fields.
- Should fix a regression issue when long placeholder/option text is provided in the Select component.
- Should add the necessary props and types to display the new status.
- Should the new status allow to see the diff given the additions and removals.