### PR TITLE
fix(scalars): allow tab navigation in the amount field component

### DIFF
--- a/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
+++ b/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`AmountField Component > should match snapshot 1`] = `
             class="flex flex-col gap-2"
           >
             <div
-              class="relative flex items-center"
+              class="relative flex items-center group"
             >
               <input
                 aria-invalid="false"
@@ -43,6 +43,50 @@ exports[`AmountField Component > should match snapshot 1`] = `
                 type="text"
                 value="345"
               />
+              <div
+                class="absolute inset-y-2 right-3 flex flex-col justify-center opacity-0 group-focus-within:opacity-100 transition-opacity"
+              >
+                <button
+                  aria-label="Increment"
+                  type="button"
+                >
+                  <svg
+                    class="rotate-180 text-gray-700 dark:text-gray-300"
+                    data-testid="icon-fallback"
+                    fill="none"
+                    stroke="currentcolor"
+                    style="width: 10px; height: 10px;"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 9L12 15L18 9"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Decrement"
+                  type="button"
+                >
+                  <svg
+                    class="items-center justify-center text-gray-700 dark:text-gray-300"
+                    data-testid="icon-fallback"
+                    fill="none"
+                    stroke="currentcolor"
+                    style="width: 10px; height: 10px;"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M6 9L12 15L18 9"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
+++ b/src/scalars/components/number-field/__snapshots__/number-field.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`NumberField > should match snapshot 1`] = `
         Test Label
       </label>
       <div
-        class="relative flex items-center"
+        class="relative flex items-center group"
       >
         <input
           aria-invalid="false"
@@ -29,6 +29,50 @@ exports[`NumberField > should match snapshot 1`] = `
           type="text"
           value="345"
         />
+        <div
+          class="absolute inset-y-2 right-3 flex flex-col justify-center opacity-0 group-focus-within:opacity-100 transition-opacity"
+        >
+          <button
+            aria-label="Increment"
+            type="button"
+          >
+            <svg
+              class="rotate-180 text-gray-700 dark:text-gray-300"
+              data-testid="icon-fallback"
+              fill="none"
+              stroke="currentcolor"
+              style="width: 10px; height: 10px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6 9L12 15L18 9"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+          <button
+            aria-label="Decrement"
+            type="button"
+          >
+            <svg
+              class="items-center justify-center text-gray-700 dark:text-gray-300"
+              data-testid="icon-fallback"
+              fill="none"
+              stroke="currentcolor"
+              style="width: 10px; height: 10px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M6 9L12 15L18 9"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </button>
+        </div>
       </div>
     </div>
   </form>

--- a/src/ui/components/data-entry/number-input/__snapshots__/number-input.test.tsx.snap
+++ b/src/ui/components/data-entry/number-input/__snapshots__/number-input.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`NumberInput > should match snapshot 1`] = `
       Test Label
     </label>
     <div
-      class="relative flex items-center"
+      class="relative flex items-center group"
     >
       <input
         aria-invalid="false"
@@ -25,6 +25,50 @@ exports[`NumberInput > should match snapshot 1`] = `
         type="text"
         value="345"
       />
+      <div
+        class="absolute inset-y-2 right-3 flex flex-col justify-center opacity-0 group-focus-within:opacity-100 transition-opacity"
+      >
+        <button
+          aria-label="Increment"
+          type="button"
+        >
+          <svg
+            class="rotate-180 text-gray-700 dark:text-gray-300"
+            data-testid="icon-fallback"
+            fill="none"
+            stroke="currentcolor"
+            style="width: 10px; height: 10px;"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 9L12 15L18 9"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+        <button
+          aria-label="Decrement"
+          type="button"
+        >
+          <svg
+            class="items-center justify-center text-gray-700 dark:text-gray-300"
+            data-testid="icon-fallback"
+            fill="none"
+            stroke="currentcolor"
+            style="width: 10px; height: 10px;"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 9L12 15L18 9"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/src/ui/components/data-entry/number-input/number-input.tsx
+++ b/src/ui/components/data-entry/number-input/number-input.tsx
@@ -32,7 +32,6 @@ const NumberInputRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
       trailingZeros = false,
       numericType = 'Float',
       precision = 0,
-      onFocus,
       // Difference Props
       baseValue,
       viewMode = 'edition',
@@ -45,14 +44,12 @@ const NumberInputRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
     const {
       canIncrement,
       canDecrement,
-      showSteps,
       preventInvalidCharsAndHandleArrows,
       stepValueHandler,
       blockInvalidPaste,
       preventLetterInput,
       isBigInt,
       handleBlur,
-      handleFocus,
       buttonRef,
     } = useNumberInput({
       value,
@@ -64,7 +61,6 @@ const NumberInputRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
       onBlur,
       trailingZeros,
       precision,
-      onFocus,
     })
 
     if (viewMode === 'edition') {
@@ -81,10 +77,9 @@ const NumberInputRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
               {label}
             </FormLabel>
           )}
-          <div className="relative flex items-center">
+          <div className="relative flex items-center group">
             <Input
               id={id}
-              onFocus={handleFocus}
               name={name}
               className={cn('pr-8', className)}
               pattern={isBigInt ? regex.toString() : pattern?.toString()}
@@ -109,53 +104,51 @@ const NumberInputRaw = forwardRef<HTMLInputElement, NumberFieldProps>(
               data-cast={isBigInt ? 'BigInt' : 'Number'}
               {...props}
             />
-            {showSteps && (
-              <div className="absolute inset-y-2 right-3 flex flex-col justify-center">
-                <button
-                  aria-label="Increment"
-                  disabled={canIncrement}
-                  onMouseDown={(e) => {
-                    e.preventDefault()
-                  }}
-                  type="button"
-                  onClick={(e) => {
-                    stepValueHandler(e, 'increment')
-                    if (buttonRef.current) {
-                      buttonRef.current.focus()
-                    }
-                  }}
-                >
-                  <Icon
-                    size={10}
-                    name="ChevronDown"
-                    className={cn('rotate-180 text-gray-700 dark:text-gray-300', canIncrement && 'cursor-not-allowed')}
-                  />
-                </button>
-                <button
-                  aria-label="Decrement"
-                  onMouseDown={(e) => {
-                    e.preventDefault()
-                  }}
-                  disabled={canDecrement}
-                  type="button"
-                  onClick={(e) => {
-                    stepValueHandler(e, 'decrement')
-                    if (buttonRef.current) {
-                      buttonRef.current.focus()
-                    }
-                  }}
-                >
-                  <Icon
-                    size={10}
-                    name="ChevronDown"
-                    className={cn(
-                      'items-center justify-center text-gray-700 dark:text-gray-300',
-                      canDecrement && 'cursor-not-allowed'
-                    )}
-                  />
-                </button>
-              </div>
-            )}
+            <div className="absolute inset-y-2 right-3 flex flex-col justify-center opacity-0 group-focus-within:opacity-100 transition-opacity">
+              <button
+                aria-label="Increment"
+                disabled={canIncrement}
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                }}
+                type="button"
+                onClick={(e) => {
+                  stepValueHandler(e, 'increment')
+                  if (buttonRef.current) {
+                    buttonRef.current.focus()
+                  }
+                }}
+              >
+                <Icon
+                  size={10}
+                  name="ChevronDown"
+                  className={cn('rotate-180 text-gray-700 dark:text-gray-300', canIncrement && 'cursor-not-allowed')}
+                />
+              </button>
+              <button
+                aria-label="Decrement"
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                }}
+                disabled={canDecrement}
+                type="button"
+                onClick={(e) => {
+                  stepValueHandler(e, 'decrement')
+                  if (buttonRef.current) {
+                    buttonRef.current.focus()
+                  }
+                }}
+              >
+                <Icon
+                  size={10}
+                  name="ChevronDown"
+                  className={cn(
+                    'items-center justify-center text-gray-700 dark:text-gray-300',
+                    canDecrement && 'cursor-not-allowed'
+                  )}
+                />
+              </button>
+            </div>
           </div>
           {description && <FormDescription>{description}</FormDescription>}
           {warnings && <FormMessageList messages={warnings} type="warning" />}

--- a/src/ui/components/data-entry/number-input/use-number-input.ts
+++ b/src/ui/components/data-entry/number-input/use-number-input.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useRef } from 'react'
 import type { NumericType } from './types.js'
 import { getDisplayValue } from './utils.js'
 import { isNotSafeValue } from '../amount-input/utils.js'
@@ -13,7 +13,6 @@ interface UseNumberFieldProps {
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void
   trailingZeros?: boolean
   precision?: number
-  onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void
 }
 
 export const useNumberInput = ({
@@ -26,9 +25,7 @@ export const useNumberInput = ({
   onBlur,
   trailingZeros = false,
   precision = 0,
-  onFocus,
 }: UseNumberFieldProps) => {
-  const [isFocus, setIsFocus] = useState(false)
   const buttonRef = useRef<HTMLButtonElement>(null)
   const canIncrement =
     maxValue !== undefined && (typeof value === 'bigint' ? value >= BigInt(maxValue) : Number(value) >= maxValue)
@@ -36,7 +33,7 @@ export const useNumberInput = ({
   const canDecrement =
     minValue !== undefined && (typeof value === 'bigint' ? value <= BigInt(minValue) : Number(value) <= minValue)
 
-  const showSteps = isFocus
+  // const showSteps = isFocus
 
   // Boolean to no convert float values to BigInt
   const isBigInt = numericType && numericType === 'BigInt'
@@ -107,7 +104,6 @@ export const useNumberInput = ({
   }
 
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    setIsFocus(false)
     const inputValue = e.target.value
 
     // If the value is not a number, not an empty string, or is empty, show the error message or keep it empty
@@ -157,24 +153,15 @@ export const useNumberInput = ({
     onBlur?.(e)
   }
 
-  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
-    e.preventDefault()
-    setIsFocus(true)
-    onFocus?.(e)
-  }
-
   return {
     canIncrement,
     canDecrement,
-    showSteps,
     preventInvalidCharsAndHandleArrows,
     stepValueHandler,
     blockInvalidPaste,
     preventLetterInput,
     isBigInt,
     handleBlur,
-    handleFocus,
-    isFocus,
     buttonRef,
   }
 }


### PR DESCRIPTION
## Ticket
- https://trello.com/c/DskTAxXq/1057-create-a-read-only-diff-status-for-the-amount-component

## Description
-  This should allow proper keyboard navigation using the Tab key.
Currently, it takes three Tab presses to move past the component, which breaks the expected navigation flow.


## Trello Item
- Should allow proper keyboard navigation using the Tab key.
Currently, it takes three Tab presses to move past the component, which breaks the expected navigation flow.


