### PR TITLE
feat(scalars & ui): add diff status to OIDInput & OIDField + PHIDInput diff fixes

### DIFF
--- a/src/scalars/components/fragments/id-autocomplete/id-autocomplete-list.tsx
+++ b/src/scalars/components/fragments/id-autocomplete/id-autocomplete-list.tsx
@@ -34,7 +34,7 @@ const IdAutocompleteList: React.FC<IdAutocompleteListProps> = ({
   previewPlaceholder,
 }) => {
   const cmdkSearch = useCommandState((state) => state.search)
-  const defaultOption: IdAutocompleteOption = previewPlaceholder || {
+  const defaultOption: IdAutocompleteOption = previewPlaceholder ?? {
     value: 'value not available',
     title: 'Title not available',
     path: 'Path not available',

--- a/src/scalars/components/fragments/id-autocomplete/id-autocomplete.tsx
+++ b/src/scalars/components/fragments/id-autocomplete/id-autocomplete.tsx
@@ -12,6 +12,7 @@ import ValueTransformer, { type TransformerType } from '../value-transformer/ind
 import { IdAutocompleteInputContainer } from './id-autocomplete-input-container.js'
 import { IdAutocompleteListOption } from './id-autocomplete-list-option.js'
 import { IdAutocompleteList } from './id-autocomplete-list.js'
+import { IdAutocompleteDiff } from './id-autocomplete-diff.js'
 import type { IdAutocompleteProps } from './types.js'
 import { useIdAutocomplete } from './use-id-autocomplete.js'
 
@@ -44,6 +45,12 @@ const IdAutocomplete = React.forwardRef<HTMLInputElement, IdAutocompleteProps>(
       initialOptions,
       renderOption,
       previewPlaceholder,
+      viewMode = 'edition',
+      baseValue,
+      basePreviewIcon,
+      basePreviewTitle,
+      basePreviewPath,
+      basePreviewDescription,
       ...props
     },
     ref
@@ -105,6 +112,26 @@ const IdAutocomplete = React.forwardRef<HTMLInputElement, IdAutocompleteProps>(
       () => [sharedValueTransformers.trimOnBlur(), sharedValueTransformers.trimOnEnter()],
       []
     )
+
+    if (viewMode !== 'edition') {
+      return (
+        <IdAutocompleteDiff
+          value={selectedValue}
+          currentOption={selectedOption}
+          label={label}
+          required={required}
+          autoComplete={autoComplete}
+          previewPlaceholder={previewPlaceholder}
+          variant={variant}
+          viewMode={viewMode}
+          baseValue={baseValue}
+          basePreviewIcon={basePreviewIcon}
+          basePreviewTitle={basePreviewTitle}
+          basePreviewPath={basePreviewPath}
+          basePreviewDescription={basePreviewDescription}
+        />
+      )
+    }
 
     return (
       <FormGroup>

--- a/src/scalars/components/fragments/id-autocomplete/types.ts
+++ b/src/scalars/components/fragments/id-autocomplete/types.ts
@@ -1,6 +1,6 @@
 import type { IconName } from '../../../../ui/components/icon/index.js'
 import type React from 'react'
-import type { InputBaseProps } from '../../types.js'
+import type { InputBaseProps, ViewMode } from '../../types.js'
 
 interface IdAutocompleteBaseConfigProps {
   onChange?: (value: string) => void
@@ -47,13 +47,6 @@ type IdAutocompleteConfigProps = IdAutocompleteBaseConfigProps &
       }
   )
 
-type IdAutocompleteProps = Omit<
-  React.InputHTMLAttributes<HTMLInputElement>,
-  keyof InputBaseProps<string> | keyof IdAutocompleteConfigProps | 'pattern'
-> &
-  InputBaseProps<string> &
-  IdAutocompleteConfigProps
-
 interface IdAutocompleteBaseOption {
   icon?: IconName | React.ReactElement
   title?: string
@@ -68,5 +61,19 @@ interface IdAutocompleteBaseOption {
 }
 
 type IdAutocompleteOption<T extends Record<string, unknown> = Record<never, unknown>> = IdAutocompleteBaseOption & T
+
+type IdAutocompleteProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  keyof InputBaseProps<string> | keyof IdAutocompleteConfigProps | 'pattern'
+> &
+  InputBaseProps<string> &
+  IdAutocompleteConfigProps & {
+    viewMode?: ViewMode
+    baseValue?: IdAutocompleteBaseOption['value']
+    basePreviewIcon?: IdAutocompleteBaseOption['icon']
+    basePreviewTitle?: IdAutocompleteBaseOption['title']
+    basePreviewPath?: IdAutocompleteBaseOption['path']
+    basePreviewDescription?: IdAutocompleteBaseOption['description']
+  }
 
 export type { IdAutocompleteOption, IdAutocompleteProps }

--- a/src/scalars/components/oid-field/oid-field.stories.tsx
+++ b/src/scalars/components/oid-field/oid-field.stories.tsx
@@ -79,6 +79,16 @@ const meta: Meta<typeof OIDField> = {
       if: { arg: 'autoComplete', neq: false },
     },
 
+    initialOptions: {
+      control: 'object',
+      description: 'Array of options to initially populate the autocomplete dropdown',
+      table: {
+        type: { summary: 'OIDOption[]' },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+      if: { arg: 'autoComplete', neq: false },
+    },
+
     previewPlaceholder: {
       control: 'object',
       description:
@@ -109,6 +119,41 @@ const meta: Meta<typeof OIDField> = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
       if: { arg: 'autoComplete', neq: false },
+    },
+
+    ...PrebuiltArgTypes.viewMode,
+    ...PrebuiltArgTypes.baseValue,
+    basePreviewIcon: {
+      control: 'object',
+      description: 'The icon of the base preview',
+      table: {
+        type: { summary: 'IconName | React.ReactElement' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewTitle: {
+      control: 'text',
+      description: 'The title of the base preview',
+      table: {
+        type: { summary: 'string' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewPath: {
+      control: 'object',
+      description: 'The path of the base preview',
+      table: {
+        type: { summary: 'string | { text: string; url: string; }' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewDescription: {
+      control: 'text',
+      description: 'The description of the base preview',
+      table: {
+        type: { summary: 'string' },
+        category: StorybookControlCategory.DIFF,
+      },
     },
 
     ...getValidationArgTypes(),
@@ -165,5 +210,59 @@ export const Filled: Story = {
     variant: 'withValueTitleAndDescription',
     fetchOptionsCallback: fetchOptions,
     fetchSelectedOptionCallback: fetchSelectedOption,
+  },
+}
+
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'OID field addition',
+    placeholder: 'uuid',
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'addition',
+    baseValue: 'abcde2a4-f9a0-4950-8161-fd8d8cc7dea7',
+    basePreviewIcon: 'Braces',
+    basePreviewTitle: 'Old Object A',
+    basePreviewPath: 'old-rwa-portfolio-a',
+    basePreviewDescription: 'Old Object A description',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'OID field removal',
+    placeholder: 'uuid',
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'removal',
+    baseValue: 'abcde2a4-f9a0-4950-8161-fd8d8cc7dea7',
+    basePreviewIcon: 'Braces',
+    basePreviewTitle: 'Old Object A',
+    basePreviewPath: 'old-rwa-portfolio-a',
+    basePreviewDescription: 'Old Object A description',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'OID field mixed',
+    placeholder: 'uuid',
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'mixed',
+    baseValue: 'abcde2a4-f9a0-4950-8161-fd8d8cc7dea7',
+    basePreviewIcon: 'Braces',
+    basePreviewTitle: 'Old Object A',
+    basePreviewPath: 'old-rwa-portfolio-a',
+    basePreviewDescription: 'Old Object A description',
   },
 }

--- a/src/scalars/components/phid-field/phid-field.stories.tsx
+++ b/src/scalars/components/phid-field/phid-field.stories.tsx
@@ -144,16 +144,6 @@ const meta: Meta<typeof PHIDField> = {
     },
 
     ...PrebuiltArgTypes.viewMode,
-    diffMode: {
-      control: 'select',
-      description: 'The mode of the input field',
-      options: ['sentences'],
-      table: {
-        type: { summary: 'sentences' },
-        defaultValue: { summary: 'sentences' },
-        category: StorybookControlCategory.DIFF,
-      },
-    },
     ...PrebuiltArgTypes.baseValue,
     basePreviewIcon: {
       control: 'text',
@@ -244,5 +234,62 @@ export const Filled: Story = {
     variant: 'withValueTitleAndDescription',
     fetchOptionsCallback: fetchOptions,
     fetchSelectedOptionCallback: fetchSelectedOption,
+  },
+}
+
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'PHID field addition',
+    placeholder: 'phd:',
+    allowUris: true,
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'addition',
+    baseValue: 'phd:abcde2a4-f9a0-4950-8161-fd8d8cc7dea7',
+    basePreviewIcon: 'PowerhouseLogoSmall',
+    basePreviewTitle: 'Old Document A',
+    basePreviewPath: 'old/projects/finance/document-a',
+    basePreviewDescription: 'Old Financial report for Q1 2024',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'PHID field removal',
+    placeholder: 'phd:',
+    allowUris: true,
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'removal',
+    baseValue: 'phd:abcde2a4-f9a0-4950-8161-fd8d8cc7dea7',
+    basePreviewIcon: 'PowerhouseLogoSmall',
+    basePreviewTitle: 'Old Document A',
+    basePreviewPath: 'old/projects/finance/document-a',
+    basePreviewDescription: 'Old Financial report for Q1 2024',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'PHID field mixed',
+    placeholder: 'phd:',
+    allowUris: true,
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'mixed',
+    baseValue: 'phd:abcde2a4-f9a0-4950-8161-fd8d8cc7dea7',
+    basePreviewIcon: 'PowerhouseLogoSmall',
+    basePreviewTitle: 'Old Document A',
+    basePreviewPath: 'old/projects/finance/document-a',
+    basePreviewDescription: 'Old Financial report for Q1 2024',
   },
 }

--- a/src/scalars/components/phid-field/phid-field.tsx
+++ b/src/scalars/components/phid-field/phid-field.tsx
@@ -17,7 +17,7 @@ const PHIDField = withFieldValidation<PHIDFieldProps>(PHIDInput, {
         const domainSegment = '[a-zA-Z0-9](?:[a-zA-Z0-9\\-]*[a-zA-Z0-9])?'
         const domain = `${domainSegment}(?:\\.${domainSegment})*`
         const uuidPattern = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
-        const genericIDPattern = '[A-Za-z0-9+/={\}\.\~?&]+'
+        const genericIDPattern = '[A-Za-z0-9+/={}.~?&]+'
         const documentIDPattern = `((${genericIDPattern})|(${uuidPattern}))`
         const URLFormat = `^phd://${domain}/${documentIDPattern}$`
 
@@ -50,7 +50,7 @@ const PHIDField = withFieldValidation<PHIDFieldProps>(PHIDInput, {
 
         // Validate scope
         if (Array.isArray(allowedScopes)) {
-          const scopeMatch = /.*:.*::([^:]+)$/.exec(value) || /.*:.*:.*:([^:]+)$/.exec(value)
+          const scopeMatch = /.*:.*::([^:]+)$/.exec(value) ?? /.*:.*:.*:([^:]+)$/.exec(value)
           if (scopeMatch && !allowedScopes.includes(scopeMatch[1])) {
             return `Invalid scope. Allowed scopes are: ${allowedScopes.join(', ')}`
           }

--- a/src/ui/components/data-entry/currency-code-picker/currency-code-picker.stories.tsx
+++ b/src/ui/components/data-entry/currency-code-picker/currency-code-picker.stories.tsx
@@ -9,17 +9,6 @@ import { CurrencyCodePicker } from './currency-code-picker.js'
 
 /**
  * The `CurrencyCodePicker` component provides a dropdown selection field for currency codes.
- * It supports multiple configuration properties like:
- * - label
- * - description
- * - placeholder
- * - currencies
- * - favoriteCurrencies
- * - includeCurrencySymbols
- * - symbolPosition
- * - allowedTypes
- * - searchable
- * - contentAlign
  *
  * Features include:
  * - Support for both fiat and crypto currencies

--- a/src/ui/components/data-entry/oid-input/__snapshots__/oid-input.test.tsx.snap
+++ b/src/ui/components/data-entry/oid-input/__snapshots__/oid-input.test.tsx.snap
@@ -1,15 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`IdAutocomplete Component > should match snapshot 1`] = `
+exports[`OIDInput Component > should match snapshot 1`] = `
 <DocumentFragment>
   <div
     class="flex flex-col gap-2"
   >
     <label
       class="inline-flex items-center text-sm font-medium leading-4 text-gray-900 dark:text-gray-50 mb-[3px]"
-      for=":r0:-id-autocomplete"
+      for=":r0:-oid"
     >
-      Id Autocomplete Input
+      OID Input
     </label>
     <div
       class="flex size-full flex-col rounded-md [&_[cmdk-label]]:hidden dark:bg-charcoal-900 bg-gray-100"
@@ -18,8 +18,8 @@ exports[`IdAutocomplete Component > should match snapshot 1`] = `
     >
       <label
         cmdk-label=""
-        for="radix-:r4:"
-        id="radix-:r3:"
+        for="radix-:r5:"
+        id="radix-:r4:"
         style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0px;"
       />
       <div
@@ -27,17 +27,17 @@ exports[`IdAutocomplete Component > should match snapshot 1`] = `
       >
         <input
           aria-autocomplete="list"
-          aria-controls="radix-:r2:"
+          aria-controls="radix-:r3:"
           aria-expanded="false"
           aria-invalid="false"
-          aria-labelledby="radix-:r3:"
+          aria-labelledby="radix-:r4:"
           autocomplete="off"
           autocorrect="off"
           class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-9"
           cmdk-input=""
-          id=":r0:-id-autocomplete"
-          name="id-autocomplete"
-          placeholder="Search..."
+          id=":r0:-oid"
+          name="oid"
+          placeholder="uuid"
           role="combobox"
           spellcheck="false"
           type="text"

--- a/src/ui/components/data-entry/oid-input/oid-input.stories.tsx
+++ b/src/ui/components/data-entry/oid-input/oid-input.stories.tsx
@@ -10,19 +10,12 @@ import { OIDInput } from './oid-input.js'
 
 /**
  * The `OIDInput` component provides an input field for Object IDs (typically UUIDs).
- * It supports multiple configuration properties like:
- * - label
- * - description
- * - autoComplete
- * - fetchOptionsCallback
- * - fetchSelectedOptionCallback
- * - previewPlaceholder
- * - variant
  *
  * Features include:
  * - Multiple display variants for autocomplete options
  * - Copy paste support
  * - Async and sync options fetching
+ * - Customizable preview placeholder with icon, title, path and description
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
  * > you can use the [OIDField](?path=/docs/scalars-oid-field--readme)
@@ -108,6 +101,16 @@ const meta: Meta<typeof OIDInput> = {
       if: { arg: 'autoComplete', neq: false },
     },
 
+    initialOptions: {
+      control: 'object',
+      description: 'Array of options to initially populate the autocomplete dropdown',
+      table: {
+        type: { summary: 'OIDOption[]' },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+      if: { arg: 'autoComplete', neq: false },
+    },
+
     previewPlaceholder: {
       control: 'object',
       description:
@@ -138,6 +141,41 @@ const meta: Meta<typeof OIDInput> = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
       if: { arg: 'autoComplete', neq: false },
+    },
+
+    ...PrebuiltArgTypes.viewMode,
+    ...PrebuiltArgTypes.baseValue,
+    basePreviewIcon: {
+      control: 'object',
+      description: 'The icon of the base preview',
+      table: {
+        type: { summary: 'IconName | React.ReactElement' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewTitle: {
+      control: 'text',
+      description: 'The title of the base preview',
+      table: {
+        type: { summary: 'string' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewPath: {
+      control: 'object',
+      description: 'The path of the base preview',
+      table: {
+        type: { summary: 'string | { text: string; url: string; }' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewDescription: {
+      control: 'text',
+      description: 'The description of the base preview',
+      table: {
+        type: { summary: 'string' },
+        category: StorybookControlCategory.DIFF,
+      },
     },
   },
   args: {
@@ -192,5 +230,59 @@ export const Filled: Story = {
     variant: 'withValueTitleAndDescription',
     fetchOptionsCallback: fetchOptions,
     fetchSelectedOptionCallback: fetchSelectedOption,
+  },
+}
+
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'OID input addition',
+    placeholder: 'uuid',
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'addition',
+    baseValue: 'abcde2a4-f9a0-4950-8161-fd8d8cc7dea7',
+    basePreviewIcon: 'Braces',
+    basePreviewTitle: 'Old Object A',
+    basePreviewPath: 'old-rwa-portfolio-a',
+    basePreviewDescription: 'Old Object A description',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'OID input removal',
+    placeholder: 'uuid',
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'removal',
+    baseValue: 'abcde2a4-f9a0-4950-8161-fd8d8cc7dea7',
+    basePreviewIcon: 'Braces',
+    basePreviewTitle: 'Old Object A',
+    basePreviewPath: 'old-rwa-portfolio-a',
+    basePreviewDescription: 'Old Object A description',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'OID input mixed',
+    placeholder: 'uuid',
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'mixed',
+    baseValue: 'abcde2a4-f9a0-4950-8161-fd8d8cc7dea7',
+    basePreviewIcon: 'Braces',
+    basePreviewTitle: 'Old Object A',
+    basePreviewPath: 'old-rwa-portfolio-a',
+    basePreviewDescription: 'Old Object A description',
   },
 }

--- a/src/ui/components/data-entry/oid-input/oid-input.test.tsx
+++ b/src/ui/components/data-entry/oid-input/oid-input.test.tsx
@@ -1,0 +1,394 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { OIDInput } from './oid-input.js'
+
+describe('OIDInput Component', () => {
+  const mockedOptions = [
+    {
+      icon: 'Braces' as const,
+      title: 'Object A',
+      path: 'rwa-portfolio-a',
+      value: 'baefc2a4-f9a0-4950-8161-fd8d8cc7dea7',
+      description: 'Object A description',
+    },
+    {
+      icon: 'Braces' as const,
+      title: 'Object B',
+      path: 'rwa-portfolio-b',
+      value: 'baefc2a4-f9a0-4950-8161-fd8d8cc6cdb8',
+      description: 'Object B description',
+    },
+  ]
+
+  const defaultGetOptions = vi.fn().mockResolvedValue(mockedOptions)
+  const defaultGetSelectedOption = vi.fn().mockImplementation((value: string) => {
+    return mockedOptions.find((option) => option.value === value)
+  })
+
+  it('should match snapshot', () => {
+    const { asFragment } = render(
+      <OIDInput
+        name="oid"
+        label="OID Input"
+        placeholder="uuid"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should render with label', () => {
+    render(
+      <OIDInput
+        name="oid"
+        label="Test Label"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+    expect(screen.getByText('Test Label')).toBeInTheDocument()
+  })
+
+  it('should render with description', () => {
+    render(
+      <OIDInput
+        name="oid"
+        label="Test Label"
+        description="Test Description"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+    expect(screen.getByText('Test Description')).toBeInTheDocument()
+  })
+
+  it('should handle disabled state', () => {
+    render(
+      <OIDInput
+        name="oid"
+        label="Test Label"
+        disabled
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+    expect(screen.getByRole('combobox')).toBeDisabled()
+  })
+
+  it('should display error messages', async () => {
+    render(
+      <OIDInput
+        name="oid"
+        label="Test Label"
+        errors={['Invalid OID format']}
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Invalid OID format')).toBeInTheDocument()
+    })
+  })
+
+  it('should display warning messages', () => {
+    render(
+      <OIDInput
+        name="oid"
+        label="Test Label"
+        warnings={['OID may be deprecated']}
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+    expect(screen.getByText('OID may be deprecated')).toBeInTheDocument()
+  })
+
+  it('should show autocomplete options', async () => {
+    const user = userEvent.setup()
+    const originalRandom = Math.random
+    Math.random = vi.fn().mockReturnValue(1)
+
+    render(
+      <OIDInput
+        name="oid"
+        label="Test Label"
+        variant="withValueTitleAndDescription"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, 'test')
+
+    await waitFor(() => {
+      expect(defaultGetOptions).toHaveBeenCalledWith('test', {})
+    })
+
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'true')
+      expect(screen.getByText(mockedOptions[0].title)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[1].title)).toBeInTheDocument()
+    })
+
+    Math.random = originalRandom
+  })
+
+  it('should have correct ARIA attributes', async () => {
+    render(
+      <OIDInput
+        name="oid"
+        label="Test Label"
+        required
+        errors={['Error message']}
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    expect(input).toHaveAttribute('aria-required', 'true')
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-invalid', 'true')
+    })
+    expect(input).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('should show correct placeholders for different variants', () => {
+    const { rerender } = render(
+      <OIDInput
+        name="oid"
+        label="Test Label"
+        variant="withValueTitleAndDescription"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+
+    expect(screen.getByText('Title not available')).toBeInTheDocument()
+    expect(screen.getByText('Type not available')).toBeInTheDocument()
+    expect(screen.getByText('Description not available')).toBeInTheDocument()
+
+    rerender(
+      <OIDInput
+        name="oid"
+        label="Test Label"
+        variant="withValueAndTitle"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+
+    expect(screen.getByText('Title not available')).toBeInTheDocument()
+    expect(screen.getByText('Type not available')).toBeInTheDocument()
+    expect(screen.queryByText('Description not available')).not.toBeInTheDocument()
+
+    rerender(
+      <OIDInput
+        name="oid"
+        label="Test Label"
+        variant="withValue"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+
+    expect(screen.queryByText('Title not available')).not.toBeInTheDocument()
+    expect(screen.queryByText('Type not available')).not.toBeInTheDocument()
+    expect(screen.queryByText('Description not available')).not.toBeInTheDocument()
+  })
+
+  it('should handle autoComplete disabled', () => {
+    render(<OIDInput name="oid" label="Test Label" autoComplete={false} />)
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('should handle value changes and auto selection', async () => {
+    const user = userEvent.setup()
+    const originalRandom = Math.random
+    Math.random = vi.fn().mockReturnValue(1)
+
+    render(
+      <OIDInput
+        name="oid"
+        label="Test Label"
+        variant="withValueTitleAndDescription"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    await user.click(input)
+    await user.type(input, mockedOptions[0].value)
+
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(mockedOptions[0].title)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].path)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].description)).toBeInTheDocument()
+    })
+
+    Math.random = originalRandom
+  })
+
+  it('should not invoke onChange on mount when it has a defaultValue', () => {
+    const onChange = vi.fn()
+    render(
+      <OIDInput
+        name="oid"
+        label="Test Label"
+        defaultValue={mockedOptions[0].value}
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+        onChange={onChange}
+      />
+    )
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  // Tests for viewMode and diffs functionality
+  describe('viewMode and diffs', () => {
+    it('should render in edition mode by default', () => {
+      render(
+        <OIDInput
+          name="oid"
+          label="Test Label"
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
+    })
+
+    it('should render in edition mode when viewMode is explicitly set to edition', () => {
+      render(
+        <OIDInput
+          name="oid"
+          label="Test Label"
+          viewMode="edition"
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is addition', () => {
+      render(
+        <OIDInput
+          name="oid"
+          label="Test Label"
+          viewMode="addition"
+          value={mockedOptions[0].value}
+          baseValue={mockedOptions[1].value}
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].value)).toBeInTheDocument()
+      expect(screen.queryByText(mockedOptions[1].value)).not.toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is removal', () => {
+      render(
+        <OIDInput
+          name="oid"
+          label="Test Label"
+          viewMode="removal"
+          value={mockedOptions[0].value}
+          baseValue={mockedOptions[1].value}
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[1].value)).toBeInTheDocument()
+      expect(screen.queryByText(mockedOptions[0].value)).not.toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is mixed', () => {
+      render(
+        <OIDInput
+          name="oid"
+          label="Test Label"
+          viewMode="mixed"
+          value={mockedOptions[0].value}
+          baseValue={mockedOptions[1].value}
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].value)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[1].value)).toBeInTheDocument()
+    })
+
+    it('should pass correct props to diff component', () => {
+      render(
+        <OIDInput
+          name="oid"
+          label="Test Label"
+          viewMode="mixed"
+          value={mockedOptions[0].value}
+          baseValue={mockedOptions[1].value}
+          required
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('*')).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].value)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[1].value)).toBeInTheDocument()
+    })
+
+    it('should handle empty value in diff mode', () => {
+      const { container } = render(
+        <OIDInput
+          name="oid"
+          label="Test Label"
+          viewMode="addition"
+          value=""
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      const diffSpans = container.querySelectorAll('span')
+      diffSpans.forEach((span) => {
+        expect(span).toHaveTextContent('')
+      })
+    })
+
+    it('should respect variant in diff mode', () => {
+      render(
+        <OIDInput
+          name="oid"
+          label="Test Label"
+          viewMode="addition"
+          value={mockedOptions[0].value}
+          initialOptions={mockedOptions}
+          variant="withValueAndTitle"
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].value)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].title)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].path)).toBeInTheDocument()
+      expect(screen.queryByText(mockedOptions[0].description)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/ui/components/data-entry/oid-input/oid-input.tsx
+++ b/src/ui/components/data-entry/oid-input/oid-input.tsx
@@ -27,7 +27,7 @@ const OIDInput = React.forwardRef<HTMLInputElement, OIDInputProps>(
       fetchOptionsCallback,
       fetchSelectedOptionCallback,
       isOpenByDefault, // to be used only in stories
-      initialOptions, // to be used only in stories
+      initialOptions,
       previewPlaceholder,
       ...props
     },
@@ -55,12 +55,12 @@ const OIDInput = React.forwardRef<HTMLInputElement, OIDInputProps>(
           title={option.title}
           path={
             displayProps?.asPlaceholder
-              ? previewPlaceholder?.path || 'Type not available'
-              : option.path || 'Type not available'
+              ? (previewPlaceholder?.path ?? 'Type not available')
+              : (option.path ?? 'Type not available')
           }
-          value={displayProps?.asPlaceholder ? previewPlaceholder?.value || 'oid not available' : option.value}
+          value={displayProps?.asPlaceholder ? (previewPlaceholder?.value ?? 'oid not available') : option.value}
           description={option.description}
-          placeholderIcon={previewPlaceholder?.icon || 'Braces'}
+          placeholderIcon={previewPlaceholder?.icon ?? 'Braces'}
           {...displayProps}
         />
       ),

--- a/src/ui/components/data-entry/oid-input/types.ts
+++ b/src/ui/components/data-entry/oid-input/types.ts
@@ -2,6 +2,14 @@ import type {
   IdAutocompleteOption,
   IdAutocompleteProps,
 } from '../../../../scalars/components/fragments/id-autocomplete/types.js'
+import type { WithDifference } from '../../../../scalars/components/types.js'
+
+interface OIDInputWithDifference extends Omit<WithDifference<string>, 'diffMode'> {
+  basePreviewIcon?: IdAutocompleteOption['icon']
+  basePreviewTitle?: IdAutocompleteOption['title']
+  basePreviewPath?: IdAutocompleteOption['path']
+  basePreviewDescription?: IdAutocompleteOption['description']
+}
 
 type OIDOption = IdAutocompleteOption
 
@@ -27,6 +35,7 @@ type OIDInputProps = OIDInputBaseProps &
         fetchSelectedOptionCallback?: (value: string) => Promise<OIDOption | undefined> | OIDOption | undefined
         previewPlaceholder?: OIDOption
       }
-  )
+  ) &
+  OIDInputWithDifference
 
 export type { OIDInputProps, OIDOption }

--- a/src/ui/components/data-entry/phid-input/__snapshots__/phid-input.test.tsx.snap
+++ b/src/ui/components/data-entry/phid-input/__snapshots__/phid-input.test.tsx.snap
@@ -1,15 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`IdAutocomplete Component > should match snapshot 1`] = `
+exports[`PHIDInput Component > should match snapshot 1`] = `
 <DocumentFragment>
   <div
     class="flex flex-col gap-2"
   >
     <label
       class="inline-flex items-center text-sm font-medium leading-4 text-gray-900 dark:text-gray-50 mb-[3px]"
-      for=":r0:-id-autocomplete"
+      for=":r0:-phid"
     >
-      Id Autocomplete Input
+      PHID Input
     </label>
     <div
       class="flex size-full flex-col rounded-md [&_[cmdk-label]]:hidden dark:bg-charcoal-900 bg-gray-100"
@@ -18,8 +18,8 @@ exports[`IdAutocomplete Component > should match snapshot 1`] = `
     >
       <label
         cmdk-label=""
-        for="radix-:r4:"
-        id="radix-:r3:"
+        for="radix-:r5:"
+        id="radix-:r4:"
         style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0px;"
       />
       <div
@@ -27,17 +27,17 @@ exports[`IdAutocomplete Component > should match snapshot 1`] = `
       >
         <input
           aria-autocomplete="list"
-          aria-controls="radix-:r2:"
+          aria-controls="radix-:r3:"
           aria-expanded="false"
           aria-invalid="false"
-          aria-labelledby="radix-:r3:"
+          aria-labelledby="radix-:r4:"
           autocomplete="off"
           autocorrect="off"
           class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-9"
           cmdk-input=""
-          id=":r0:-id-autocomplete"
-          name="id-autocomplete"
-          placeholder="Search..."
+          id=":r0:-phid"
+          name="phid"
+          placeholder="phd:"
           role="combobox"
           spellcheck="false"
           type="text"

--- a/src/ui/components/data-entry/phid-input/phid-input.stories.tsx
+++ b/src/ui/components/data-entry/phid-input/phid-input.stories.tsx
@@ -10,19 +10,12 @@ import { PHIDInput } from './phid-input.js'
 
 /**
  * The `PHIDInput` component provides an input field for Powerhouse IDs.
- * It supports multiple configuration properties like:
- * - label
- * - description
- * - autoComplete
- * - fetchOptionsCallback
- * - fetchSelectedOptionCallback
- * - previewPlaceholder
- * - variant
  *
  * Features include:
  * - Multiple display variants for autocomplete options
  * - Copy paste support
  * - Async and sync options fetching
+ * - Customizable preview placeholder with icon, title, path and description
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
  * > you can use the [PHIDField](?path=/docs/scalars-phid-field--readme)
@@ -173,19 +166,9 @@ const meta: Meta<typeof PHIDInput> = {
     },
 
     ...PrebuiltArgTypes.viewMode,
-    diffMode: {
-      control: 'select',
-      description: 'The mode of the input field',
-      options: ['sentences'],
-      table: {
-        type: { summary: 'sentences' },
-        defaultValue: { summary: 'sentences' },
-        category: StorybookControlCategory.DIFF,
-      },
-    },
     ...PrebuiltArgTypes.baseValue,
     basePreviewIcon: {
-      control: 'text',
+      control: 'object',
       description: 'The icon of the base preview',
       table: {
         type: { summary: 'IconName | React.ReactElement' },
@@ -201,10 +184,10 @@ const meta: Meta<typeof PHIDInput> = {
       },
     },
     basePreviewPath: {
-      control: 'text',
+      control: 'object',
       description: 'The path of the base preview',
       table: {
-        type: { summary: 'string' },
+        type: { summary: 'string | { text: string; url: string; }' },
         category: StorybookControlCategory.DIFF,
       },
     },
@@ -271,5 +254,62 @@ export const Filled: Story = {
     variant: 'withValueTitleAndDescription',
     fetchOptionsCallback: fetchOptions,
     fetchSelectedOptionCallback: fetchSelectedOption,
+  },
+}
+
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'PHID input addition',
+    placeholder: 'phd:',
+    allowUris: true,
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'addition',
+    baseValue: 'phd:abcde2a4-f9a0-4950-8161-fd8d8cc7dea7',
+    basePreviewIcon: 'PowerhouseLogoSmall',
+    basePreviewTitle: 'Old Document A',
+    basePreviewPath: 'old/projects/finance/document-a',
+    basePreviewDescription: 'Old Financial report for Q1 2024',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'PHID input removal',
+    placeholder: 'phd:',
+    allowUris: true,
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'removal',
+    baseValue: 'phd:abcde2a4-f9a0-4950-8161-fd8d8cc7dea7',
+    basePreviewIcon: 'PowerhouseLogoSmall',
+    basePreviewTitle: 'Old Document A',
+    basePreviewPath: 'old/projects/finance/document-a',
+    basePreviewDescription: 'Old Financial report for Q1 2024',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'PHID input mixed',
+    placeholder: 'phd:',
+    allowUris: true,
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'mixed',
+    baseValue: 'phd:abcde2a4-f9a0-4950-8161-fd8d8cc7dea7',
+    basePreviewIcon: 'PowerhouseLogoSmall',
+    basePreviewTitle: 'Old Document A',
+    basePreviewPath: 'old/projects/finance/document-a',
+    basePreviewDescription: 'Old Financial report for Q1 2024',
   },
 }

--- a/src/ui/components/data-entry/phid-input/phid-input.test.tsx
+++ b/src/ui/components/data-entry/phid-input/phid-input.test.tsx
@@ -1,35 +1,22 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
-import { IdAutocomplete } from './id-autocomplete.js'
+import { PHIDInput } from './phid-input.js'
 
-describe('IdAutocomplete Component', () => {
-  window.HTMLElement.prototype.scrollIntoView = vi.fn()
-  window.Element.prototype.scrollTo = vi.fn()
-  window.matchMedia = vi.fn().mockImplementation((query) => ({
-    matches: false,
-    media: query as string,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  }))
-
+describe('PHIDInput Component', () => {
   const mockedOptions = [
     {
-      icon: 'PowerhouseLogoSmall',
+      icon: 'PowerhouseLogoSmall' as const,
       title: 'Document A',
       path: 'projects/finance/document-a',
-      value: 'document-a',
+      value: 'phd:baefc2a4-f9a0-4950-8161-fd8d8cc7dea7:main:public',
       description: 'Financial report for Q1 2024',
     },
     {
-      icon: 'PowerhouseLogoSmall',
+      icon: 'PowerhouseLogoSmall' as const,
       title: 'Document B',
       path: 'projects/legal/document-b',
-      value: 'document-b',
+      value: 'phd:baefc2a4-f9a0-4950-8161-fd8d8cc6cdb8:main:public',
       description: 'Legal compliance documentation',
     },
   ]
@@ -41,10 +28,10 @@ describe('IdAutocomplete Component', () => {
 
   it('should match snapshot', () => {
     const { asFragment } = render(
-      <IdAutocomplete
-        name="id-autocomplete"
-        label="Id Autocomplete Input"
-        placeholder="Search..."
+      <PHIDInput
+        name="phid"
+        label="PHID Input"
+        placeholder="phd:"
         fetchOptionsCallback={defaultGetOptions}
         fetchSelectedOptionCallback={defaultGetSelectedOption}
       />
@@ -54,8 +41,8 @@ describe('IdAutocomplete Component', () => {
 
   it('should render with label', () => {
     render(
-      <IdAutocomplete
-        name="id-autocomplete"
+      <PHIDInput
+        name="phid"
         label="Test Label"
         fetchOptionsCallback={defaultGetOptions}
         fetchSelectedOptionCallback={defaultGetSelectedOption}
@@ -66,8 +53,8 @@ describe('IdAutocomplete Component', () => {
 
   it('should render with description', () => {
     render(
-      <IdAutocomplete
-        name="id-autocomplete"
+      <PHIDInput
+        name="phid"
         label="Test Label"
         description="Test Description"
         fetchOptionsCallback={defaultGetOptions}
@@ -79,8 +66,8 @@ describe('IdAutocomplete Component', () => {
 
   it('should handle disabled state', () => {
     render(
-      <IdAutocomplete
-        name="id-autocomplete"
+      <PHIDInput
+        name="phid"
         label="Test Label"
         disabled
         fetchOptionsCallback={defaultGetOptions}
@@ -92,30 +79,30 @@ describe('IdAutocomplete Component', () => {
 
   it('should display error messages', async () => {
     render(
-      <IdAutocomplete
-        name="id-autocomplete"
+      <PHIDInput
+        name="phid"
         label="Test Label"
-        errors={['Invalid format']}
+        errors={['Invalid PHID format']}
         fetchOptionsCallback={defaultGetOptions}
         fetchSelectedOptionCallback={defaultGetSelectedOption}
       />
     )
     await waitFor(() => {
-      expect(screen.getByText('Invalid format')).toBeInTheDocument()
+      expect(screen.getByText('Invalid PHID format')).toBeInTheDocument()
     })
   })
 
   it('should display warning messages', () => {
     render(
-      <IdAutocomplete
-        name="id-autocomplete"
+      <PHIDInput
+        name="phid"
         label="Test Label"
-        warnings={['Option may be deprecated']}
+        warnings={['PHID may be deprecated']}
         fetchOptionsCallback={defaultGetOptions}
         fetchSelectedOptionCallback={defaultGetSelectedOption}
       />
     )
-    expect(screen.getByText('Option may be deprecated')).toBeInTheDocument()
+    expect(screen.getByText('PHID may be deprecated')).toBeInTheDocument()
   })
 
   it('should show autocomplete options', async () => {
@@ -124,8 +111,8 @@ describe('IdAutocomplete Component', () => {
     Math.random = vi.fn().mockReturnValue(1)
 
     render(
-      <IdAutocomplete
-        name="id-autocomplete"
+      <PHIDInput
+        name="phid"
         label="Test Label"
         variant="withValueTitleAndDescription"
         fetchOptionsCallback={defaultGetOptions}
@@ -139,7 +126,10 @@ describe('IdAutocomplete Component', () => {
     await user.type(input, 'test')
 
     await waitFor(() => {
-      expect(defaultGetOptions).toHaveBeenCalledWith('test', {})
+      expect(defaultGetOptions).toHaveBeenCalledWith('test', {
+        allowUris: undefined,
+        allowedScopes: undefined,
+      })
     })
 
     await waitFor(() => {
@@ -153,8 +143,8 @@ describe('IdAutocomplete Component', () => {
 
   it('should have correct ARIA attributes', async () => {
     render(
-      <IdAutocomplete
-        name="id-autocomplete"
+      <PHIDInput
+        name="phid"
         label="Test Label"
         required
         errors={['Error message']}
@@ -173,8 +163,8 @@ describe('IdAutocomplete Component', () => {
 
   it('should show correct placeholders for different variants', () => {
     const { rerender } = render(
-      <IdAutocomplete
-        name="id-autocomplete"
+      <PHIDInput
+        name="phid"
         label="Test Label"
         variant="withValueTitleAndDescription"
         fetchOptionsCallback={defaultGetOptions}
@@ -183,12 +173,12 @@ describe('IdAutocomplete Component', () => {
     )
 
     expect(screen.getByText('Title not available')).toBeInTheDocument()
-    expect(screen.getByText('Path not available')).toBeInTheDocument()
+    expect(screen.getByText('Type not available')).toBeInTheDocument()
     expect(screen.getByText('Description not available')).toBeInTheDocument()
 
     rerender(
-      <IdAutocomplete
-        name="id-autocomplete"
+      <PHIDInput
+        name="phid"
         label="Test Label"
         variant="withValueAndTitle"
         fetchOptionsCallback={defaultGetOptions}
@@ -197,12 +187,12 @@ describe('IdAutocomplete Component', () => {
     )
 
     expect(screen.getByText('Title not available')).toBeInTheDocument()
-    expect(screen.getByText('Path not available')).toBeInTheDocument()
+    expect(screen.getByText('Type not available')).toBeInTheDocument()
     expect(screen.queryByText('Description not available')).not.toBeInTheDocument()
 
     rerender(
-      <IdAutocomplete
-        name="id-autocomplete"
+      <PHIDInput
+        name="phid"
         label="Test Label"
         variant="withValue"
         fetchOptionsCallback={defaultGetOptions}
@@ -216,7 +206,7 @@ describe('IdAutocomplete Component', () => {
   })
 
   it('should handle autoComplete disabled', () => {
-    render(<IdAutocomplete name="id-autocomplete" label="Test Label" autoComplete={false} />)
+    render(<PHIDInput name="phid" label="Test Label" autoComplete={false} />)
 
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
     expect(screen.getByRole('textbox')).toBeInTheDocument()
@@ -228,8 +218,8 @@ describe('IdAutocomplete Component', () => {
     Math.random = vi.fn().mockReturnValue(1)
 
     render(
-      <IdAutocomplete
-        name="id-autocomplete"
+      <PHIDInput
+        name="phid"
         label="Test Label"
         variant="withValueTitleAndDescription"
         fetchOptionsCallback={defaultGetOptions}
@@ -257,8 +247,8 @@ describe('IdAutocomplete Component', () => {
   it('should not invoke onChange on mount when it has a defaultValue', () => {
     const onChange = vi.fn()
     render(
-      <IdAutocomplete
-        name="id-autocomplete"
+      <PHIDInput
+        name="phid"
         label="Test Label"
         defaultValue={mockedOptions[0].value}
         fetchOptionsCallback={defaultGetOptions}
@@ -267,5 +257,141 @@ describe('IdAutocomplete Component', () => {
       />
     )
     expect(onChange).not.toHaveBeenCalled()
+  })
+
+  // Tests for viewMode and diffs functionality
+  describe('viewMode and diffs', () => {
+    it('should render in edition mode by default', () => {
+      render(
+        <PHIDInput
+          name="phid"
+          label="Test Label"
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
+    })
+
+    it('should render in edition mode when viewMode is explicitly set to edition', () => {
+      render(
+        <PHIDInput
+          name="phid"
+          label="Test Label"
+          viewMode="edition"
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is addition', () => {
+      render(
+        <PHIDInput
+          name="phid"
+          label="Test Label"
+          viewMode="addition"
+          value={mockedOptions[0].value}
+          baseValue={mockedOptions[1].value}
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].value)).toBeInTheDocument()
+      expect(screen.queryByText(mockedOptions[1].value)).not.toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is removal', () => {
+      render(
+        <PHIDInput
+          name="phid"
+          label="Test Label"
+          viewMode="removal"
+          value={mockedOptions[0].value}
+          baseValue={mockedOptions[1].value}
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[1].value)).toBeInTheDocument()
+      expect(screen.queryByText(mockedOptions[0].value)).not.toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is mixed', () => {
+      render(
+        <PHIDInput
+          name="phid"
+          label="Test Label"
+          viewMode="mixed"
+          value={mockedOptions[0].value}
+          baseValue={mockedOptions[1].value}
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].value)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[1].value)).toBeInTheDocument()
+    })
+
+    it('should pass correct props to diff component', () => {
+      render(
+        <PHIDInput
+          name="phid"
+          label="Test Label"
+          viewMode="mixed"
+          value={mockedOptions[0].value}
+          baseValue={mockedOptions[1].value}
+          required
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('*')).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].value)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[1].value)).toBeInTheDocument()
+    })
+
+    it('should handle empty value in diff mode', () => {
+      const { container } = render(
+        <PHIDInput
+          name="phid"
+          label="Test Label"
+          viewMode="addition"
+          value=""
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      const diffSpans = container.querySelectorAll('span')
+      diffSpans.forEach((span) => {
+        expect(span).toHaveTextContent('')
+      })
+    })
+
+    it('should respect variant in diff mode', () => {
+      render(
+        <PHIDInput
+          name="phid"
+          label="Test Label"
+          viewMode="addition"
+          value={mockedOptions[0].value}
+          initialOptions={mockedOptions}
+          variant="withValueAndTitle"
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].value)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].title)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].path)).toBeInTheDocument()
+      expect(screen.queryByText(mockedOptions[0].description)).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/ui/components/data-entry/phid-input/phid-input.tsx
+++ b/src/ui/components/data-entry/phid-input/phid-input.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useId, useMemo } from 'react'
 import { IdAutocompleteContext } from '../../../../scalars/components/fragments/id-autocomplete/id-autocomplete-context.js'
 import { IdAutocompleteListOption } from '../../../../scalars/components/fragments/id-autocomplete/id-autocomplete-list-option.js'
 import { IdAutocomplete } from '../../../../scalars/components/fragments/id-autocomplete/index.js'
-import { PHIDInputDiff } from './phid-input-diff.js'
 import type { PHIDInputProps, PHIDOption } from './types.js'
 
 const PHIDInput = React.forwardRef<HTMLInputElement, PHIDInputProps>(
@@ -34,14 +33,6 @@ const PHIDInput = React.forwardRef<HTMLInputElement, PHIDInputProps>(
       isOpenByDefault, // to be used only in stories
       initialOptions,
       previewPlaceholder,
-      // Diff props
-      viewMode = 'edition',
-      diffMode,
-      baseValue,
-      basePreviewIcon,
-      basePreviewTitle,
-      basePreviewPath,
-      basePreviewDescription,
       ...props
     },
     ref
@@ -70,96 +61,75 @@ const PHIDInput = React.forwardRef<HTMLInputElement, PHIDInputProps>(
           title={option.title}
           path={
             displayProps?.asPlaceholder
-              ? previewPlaceholder?.path || 'Type not available'
-              : option.path || 'Type not available'
+              ? (previewPlaceholder?.path ?? 'Type not available')
+              : (option.path ?? 'Type not available')
           }
-          value={displayProps?.asPlaceholder ? previewPlaceholder?.value || 'phid not available' : option.value}
+          value={displayProps?.asPlaceholder ? (previewPlaceholder?.value ?? 'phid not available') : option.value}
           description={option.description}
-          placeholderIcon={previewPlaceholder?.icon || undefined}
+          placeholderIcon={previewPlaceholder?.icon}
           {...displayProps}
         />
       ),
       [variant, previewPlaceholder]
     )
 
-    if (viewMode === 'edition') {
-      return (
-        <IdAutocompleteContext.Provider value={contextValue}>
-          {autoComplete && fetchOptionsCallback ? (
-            <IdAutocomplete
-              id={id}
-              name={name}
-              className={className}
-              label={label}
-              description={description}
-              value={value}
-              defaultValue={defaultValue}
-              disabled={disabled}
-              placeholder={placeholder}
-              required={required}
-              errors={errors}
-              warnings={warnings}
-              onChange={onChange}
-              onBlur={onBlur}
-              onClick={onClick}
-              onMouseDown={onMouseDown}
-              autoComplete={true}
-              variant={variant}
-              maxLength={maxLength}
-              fetchOptionsCallback={fetchOptionsCallback}
-              fetchSelectedOptionCallback={fetchSelectedOptionCallback}
-              isOpenByDefault={isOpenByDefault}
-              initialOptions={initialOptions}
-              renderOption={renderOption}
-              previewPlaceholder={previewPlaceholder}
-              {...props}
-              ref={ref}
-            />
-          ) : (
-            <IdAutocomplete
-              id={id}
-              name={name}
-              className={className}
-              label={label}
-              description={description}
-              value={value}
-              defaultValue={defaultValue}
-              disabled={disabled}
-              placeholder={placeholder}
-              required={required}
-              errors={errors}
-              warnings={warnings}
-              onChange={onChange}
-              onBlur={onBlur}
-              onClick={onClick}
-              onMouseDown={onMouseDown}
-              autoComplete={false}
-              maxLength={maxLength}
-              {...props}
-              ref={ref}
-            />
-          )}
-        </IdAutocompleteContext.Provider>
-      )
-    }
-
     return (
-      <PHIDInputDiff
-        value={value ?? defaultValue ?? ''}
-        label={label}
-        required={required}
-        autoComplete={autoComplete}
-        initialOptions={initialOptions}
-        previewPlaceholder={previewPlaceholder}
-        variant={variant}
-        viewMode={viewMode}
-        diffMode={diffMode}
-        baseValue={baseValue}
-        basePreviewIcon={basePreviewIcon}
-        basePreviewTitle={basePreviewTitle}
-        basePreviewPath={basePreviewPath}
-        basePreviewDescription={basePreviewDescription}
-      />
+      <IdAutocompleteContext.Provider value={contextValue}>
+        {autoComplete && fetchOptionsCallback ? (
+          <IdAutocomplete
+            id={id}
+            name={name}
+            className={className}
+            label={label}
+            description={description}
+            value={value}
+            defaultValue={defaultValue}
+            disabled={disabled}
+            placeholder={placeholder}
+            required={required}
+            errors={errors}
+            warnings={warnings}
+            onChange={onChange}
+            onBlur={onBlur}
+            onClick={onClick}
+            onMouseDown={onMouseDown}
+            autoComplete={true}
+            variant={variant}
+            maxLength={maxLength}
+            fetchOptionsCallback={fetchOptionsCallback}
+            fetchSelectedOptionCallback={fetchSelectedOptionCallback}
+            isOpenByDefault={isOpenByDefault}
+            initialOptions={initialOptions}
+            renderOption={renderOption}
+            previewPlaceholder={previewPlaceholder}
+            {...props}
+            ref={ref}
+          />
+        ) : (
+          <IdAutocomplete
+            id={id}
+            name={name}
+            className={className}
+            label={label}
+            description={description}
+            value={value}
+            defaultValue={defaultValue}
+            disabled={disabled}
+            placeholder={placeholder}
+            required={required}
+            errors={errors}
+            warnings={warnings}
+            onChange={onChange}
+            onBlur={onBlur}
+            onClick={onClick}
+            onMouseDown={onMouseDown}
+            autoComplete={false}
+            maxLength={maxLength}
+            {...props}
+            ref={ref}
+          />
+        )}
+      </IdAutocompleteContext.Provider>
     )
   }
 )

--- a/src/ui/components/data-entry/phid-input/types.ts
+++ b/src/ui/components/data-entry/phid-input/types.ts
@@ -2,14 +2,13 @@ import type {
   IdAutocompleteOption,
   IdAutocompleteProps,
 } from '../../../../scalars/components/fragments/id-autocomplete/types.js'
-import type { DiffMode, WithDifference } from '../../../../scalars/components/types.js'
+import type { WithDifference } from '../../../../scalars/components/types.js'
 
-export interface PHIDInputWithDifference extends Omit<WithDifference<string>, 'diffMode'> {
-  diffMode?: Extract<DiffMode, 'sentences'>
-  basePreviewIcon?: string | React.ReactElement
-  basePreviewTitle?: string
-  basePreviewPath?: string
-  basePreviewDescription?: string
+interface PHIDInputWithDifference extends Omit<WithDifference<string>, 'diffMode'> {
+  basePreviewIcon?: IdAutocompleteOption['icon']
+  basePreviewTitle?: IdAutocompleteOption['title']
+  basePreviewPath?: IdAutocompleteOption['path']
+  basePreviewDescription?: IdAutocompleteOption['description']
 }
 
 type PHIDOption = IdAutocompleteOption

--- a/src/ui/components/data-entry/select/select.stories.tsx
+++ b/src/ui/components/data-entry/select/select.stories.tsx
@@ -10,16 +10,6 @@ import { Select } from './select.js'
 
 /**
  * The `Select` component provides a dropdown selection field.
- * It supports multiple configuration properties like:
- * - label
- * - description
- * - placeholder
- * - options
- * - multiple
- * - searchable
- * - selectionIcon
- * - selectionIconPosition
- * - contentAlign
  *
  * Features include:
  * - Single and multiple selection modes


### PR DESCRIPTION
## Ticket
https://trello.com/c/lSGgXcAy/1058-create-a-read-only-diff-status-for-the-oid-component

## Description
- Should add tests to PHIDInput.
- Should fix differences in PHIDInput.
- Should add tests to OIDInput.
- Should add the necessary props and types to display the new status.
- Should the new status allow to see the diff given the additions and removals.