### PR TITLE
feat(scalars & ui): add diff status to AIDInput & AIDField

### DIFF
--- a/src/scalars/components/aid-field/aid-field.stories.tsx
+++ b/src/scalars/components/aid-field/aid-field.stories.tsx
@@ -93,6 +93,16 @@ const meta: Meta<typeof AIDField> = {
       if: { arg: 'autoComplete', neq: false },
     },
 
+    initialOptions: {
+      control: 'object',
+      description: 'Array of options to initially populate the autocomplete dropdown',
+      table: {
+        type: { summary: 'AIDOption[]' },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+      if: { arg: 'autoComplete', neq: false },
+    },
+
     previewPlaceholder: {
       control: 'object',
       description:
@@ -124,6 +134,49 @@ const meta: Meta<typeof AIDField> = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
       if: { arg: 'autoComplete', neq: false },
+    },
+
+    ...PrebuiltArgTypes.viewMode,
+    ...PrebuiltArgTypes.baseValue,
+    basePreviewIcon: {
+      control: 'object',
+      description: 'The icon of the base preview',
+      table: {
+        type: { summary: 'IconName | React.ReactElement' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewTitle: {
+      control: 'text',
+      description: 'The title of the base preview',
+      table: {
+        type: { summary: 'string' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewPath: {
+      control: 'object',
+      description: 'The path of the base preview',
+      table: {
+        type: { summary: 'string | { text: string; url: string; }' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewDescription: {
+      control: 'text',
+      description: 'The description of the base preview',
+      table: {
+        type: { summary: 'string' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewAgentType: {
+      control: 'text',
+      description: 'The agent type of the base preview',
+      table: {
+        type: { summary: 'string' },
+        category: StorybookControlCategory.DIFF,
+      },
     },
 
     ...getValidationArgTypes(),
@@ -180,5 +233,71 @@ export const Filled: Story = {
     variant: 'withValueTitleAndDescription',
     fetchOptionsCallback: fetchOptions,
     fetchSelectedOptionCallback: fetchSelectedOption,
+  },
+}
+
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'AID field addition',
+    placeholder: 'did:ethr:',
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'addition',
+    baseValue: 'did:ethr:0xabcde14089478a327f09197987f16f9e5d936e8a',
+    basePreviewIcon: 'Person',
+    basePreviewTitle: 'Old Agent A',
+    basePreviewPath: {
+      text: 'old-renown.id/0xb9c5714089478a327f09197987f16f9e5d936e8a',
+      url: 'https://www.old-renown.id/',
+    },
+    basePreviewDescription: 'Old Agent A description',
+    basePreviewAgentType: 'Old Human Contributor',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'AID field removal',
+    placeholder: 'did:ethr:',
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'removal',
+    baseValue: 'did:ethr:0xabcde14089478a327f09197987f16f9e5d936e8a',
+    basePreviewIcon: 'Person',
+    basePreviewTitle: 'Old Agent A',
+    basePreviewPath: {
+      text: 'old-renown.id/0xb9c5714089478a327f09197987f16f9e5d936e8a',
+      url: 'https://www.old-renown.id/',
+    },
+    basePreviewDescription: 'Old Agent A description',
+    basePreviewAgentType: 'Old Human Contributor',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'AID field mixed',
+    placeholder: 'did:ethr:',
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'mixed',
+    baseValue: 'did:ethr:0xabcde14089478a327f09197987f16f9e5d936e8a',
+    basePreviewIcon: 'Person',
+    basePreviewTitle: 'Old Agent A',
+    basePreviewPath: {
+      text: 'old-renown.id/0xb9c5714089478a327f09197987f16f9e5d936e8a',
+      url: 'https://www.old-renown.id/',
+    },
+    basePreviewDescription: 'Old Agent A description',
+    basePreviewAgentType: 'Old Human Contributor',
   },
 }

--- a/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
+++ b/src/scalars/components/currency-code-field/currency-code-field.stories.tsx
@@ -75,6 +75,8 @@ const meta: Meta<typeof CurrencyCodeField> = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
     },
+    ...PrebuiltArgTypes.viewMode,
+    ...PrebuiltArgTypes.baseValue,
   },
 
   args: {

--- a/src/scalars/components/fragments/id-autocomplete/id-autocomplete-diff.tsx
+++ b/src/scalars/components/fragments/id-autocomplete/id-autocomplete-diff.tsx
@@ -39,6 +39,7 @@ interface IdAutocompleteDiffProps {
   basePreviewTitle: IdAutocompleteProps['basePreviewTitle']
   basePreviewPath: IdAutocompleteProps['basePreviewPath']
   basePreviewDescription: IdAutocompleteProps['basePreviewDescription']
+  renderExtraDiffs: IdAutocompleteProps['renderExtraDiffs']
 }
 
 const IdAutocompleteDiff = ({
@@ -49,27 +50,28 @@ const IdAutocompleteDiff = ({
   autoComplete,
   previewPlaceholder,
   variant,
-  viewMode,
+  viewMode = 'addition',
   baseValue = '',
   basePreviewIcon,
   basePreviewTitle = '',
   basePreviewPath = '',
   basePreviewDescription = '',
+  renderExtraDiffs,
 }: IdAutocompleteDiffProps) => {
   const previewPlaceholderPath =
     (typeof previewPlaceholder?.path === 'object' ? previewPlaceholder.path.text : previewPlaceholder?.path) ?? ''
   const basePreviewPathText = typeof basePreviewPath === 'object' ? basePreviewPath.text : basePreviewPath
+  const basePreviewPathUrl = typeof basePreviewPath === 'object' ? basePreviewPath.url : undefined
 
   const previewTitle = currentOption?.title ?? ''
-  const previewPath = (typeof currentOption?.path === 'object' ? currentOption.path.text : currentOption?.path) ?? ''
+  const previewPathText =
+    (typeof currentOption?.path === 'object' ? currentOption.path.text : currentOption?.path) ?? ''
+  const previewPathUrl = typeof currentOption?.path === 'object' ? currentOption.path.url : undefined
   const previewDescription = currentOption?.description ?? ''
 
-  // TODO: implement real icon differences
   const placeholderIcon = previewPlaceholder?.icon ?? 'PowerhouseLogoSmall'
-
   const baseIcon = basePreviewIcon ?? placeholderIcon
   const baseIconAsPlaceholder = !basePreviewIcon
-
   const currentIcon = currentOption?.icon ?? placeholderIcon
   const currentIconAsPlaceholder = !currentOption?.icon
 
@@ -125,14 +127,32 @@ const IdAutocompleteDiff = ({
 
                     {/* left preview path */}
                     {((viewMode === 'removal' || viewMode === 'mixed') && basePreviewPathText === '') ||
-                    (viewMode === 'addition' && previewPath === '') ? (
+                    (viewMode === 'addition' && previewPathText === '') ? (
                       <span className={cn('w-full truncate text-xs leading-[18px] text-gray-400')}>
-                        {previewPlaceholderPath === '' ? 'Type not available' : previewPlaceholderPath}
+                        {previewPlaceholderPath === '' ? 'Path not available' : previewPlaceholderPath}
                       </span>
+                    ) : (viewMode === 'addition' && previewPathUrl) ||
+                      ((viewMode === 'removal' || viewMode === 'mixed') && basePreviewPathUrl) ? (
+                      <a
+                        href={viewMode === 'addition' ? previewPathUrl : basePreviewPathUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={cn(
+                          'truncate text-xs leading-[18px] text-blue-900 hover:underline focus-visible:outline-none'
+                        )}
+                      >
+                        <TextDiff
+                          baseValue={basePreviewPathText}
+                          value={previewPathText}
+                          viewMode={viewMode === 'mixed' ? 'removal' : viewMode}
+                          diffMode="sentences"
+                          className={cn('text-blue-900')}
+                        />
+                      </a>
                     ) : (
                       <TextDiff
                         baseValue={basePreviewPathText}
-                        value={previewPath}
+                        value={previewPathText}
                         viewMode={viewMode === 'mixed' ? 'removal' : viewMode}
                         diffMode="sentences"
                         className={cn('w-full truncate text-xs leading-[18px] text-gray-500')}
@@ -163,14 +183,31 @@ const IdAutocompleteDiff = ({
                       )}
 
                       {/* right preview path */}
-                      {previewPath === '' ? (
+                      {previewPathText === '' ? (
                         <span className={cn('w-full truncate text-xs leading-[18px] text-gray-400')}>
-                          {previewPlaceholderPath === '' ? 'Type not available' : previewPlaceholderPath}
+                          {previewPlaceholderPath === '' ? 'Path not available' : previewPlaceholderPath}
                         </span>
+                      ) : previewPathUrl ? (
+                        <a
+                          href={previewPathUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={cn(
+                            'truncate text-xs leading-[18px] text-blue-900 hover:underline focus-visible:outline-none'
+                          )}
+                        >
+                          <TextDiff
+                            baseValue={basePreviewPathText}
+                            value={previewPathText}
+                            viewMode="addition"
+                            diffMode="sentences"
+                            className={cn('text-blue-900')}
+                          />
+                        </a>
                       ) : (
                         <TextDiff
                           baseValue={basePreviewPathText}
-                          value={previewPath}
+                          value={previewPathText}
                           viewMode="addition"
                           diffMode="sentences"
                           className={cn('w-full truncate text-xs leading-[18px] text-gray-500')}
@@ -223,6 +260,9 @@ const IdAutocompleteDiff = ({
                   )}
                 </div>
               )}
+
+              {variant === 'withValueTitleAndDescription' &&
+                renderExtraDiffs?.(viewMode, previewPlaceholder, currentOption)}
             </div>
           </div>
         )}

--- a/src/scalars/components/fragments/id-autocomplete/id-autocomplete-list-option.tsx
+++ b/src/scalars/components/fragments/id-autocomplete/id-autocomplete-list-option.tsx
@@ -65,7 +65,8 @@ type IdAutocompleteListOptionProps = {
   isFetchSelectedOptionSync?: boolean
   className?: string
   placeholderIcon?: IconName | React.ReactElement
-} & IdAutocompleteOption<Record<string, unknown>>
+} & IdAutocompleteOption &
+  Record<string, unknown>
 
 const IdAutocompleteListOption: React.FC<IdAutocompleteListOptionProps> = ({
   variant = 'withValue',

--- a/src/scalars/components/fragments/id-autocomplete/id-autocomplete.tsx
+++ b/src/scalars/components/fragments/id-autocomplete/id-autocomplete.tsx
@@ -51,6 +51,7 @@ const IdAutocomplete = React.forwardRef<HTMLInputElement, IdAutocompleteProps>(
       basePreviewTitle,
       basePreviewPath,
       basePreviewDescription,
+      renderExtraDiffs,
       ...props
     },
     ref
@@ -129,6 +130,7 @@ const IdAutocomplete = React.forwardRef<HTMLInputElement, IdAutocompleteProps>(
           basePreviewTitle={basePreviewTitle}
           basePreviewPath={basePreviewPath}
           basePreviewDescription={basePreviewDescription}
+          renderExtraDiffs={renderExtraDiffs}
         />
       )
     }

--- a/src/scalars/components/fragments/id-autocomplete/types.ts
+++ b/src/scalars/components/fragments/id-autocomplete/types.ts
@@ -47,7 +47,7 @@ type IdAutocompleteConfigProps = IdAutocompleteBaseConfigProps &
       }
   )
 
-interface IdAutocompleteBaseOption {
+interface IdAutocompleteOption {
   icon?: IconName | React.ReactElement
   title?: string
   path?:
@@ -60,8 +60,6 @@ interface IdAutocompleteBaseOption {
   description?: string
 }
 
-type IdAutocompleteOption<T extends Record<string, unknown> = Record<never, unknown>> = IdAutocompleteBaseOption & T
-
 type IdAutocompleteProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
   keyof InputBaseProps<string> | keyof IdAutocompleteConfigProps | 'pattern'
@@ -69,11 +67,16 @@ type IdAutocompleteProps = Omit<
   InputBaseProps<string> &
   IdAutocompleteConfigProps & {
     viewMode?: ViewMode
-    baseValue?: IdAutocompleteBaseOption['value']
-    basePreviewIcon?: IdAutocompleteBaseOption['icon']
-    basePreviewTitle?: IdAutocompleteBaseOption['title']
-    basePreviewPath?: IdAutocompleteBaseOption['path']
-    basePreviewDescription?: IdAutocompleteBaseOption['description']
+    baseValue?: IdAutocompleteOption['value']
+    basePreviewIcon?: IdAutocompleteOption['icon']
+    basePreviewTitle?: IdAutocompleteOption['title']
+    basePreviewPath?: IdAutocompleteOption['path']
+    basePreviewDescription?: IdAutocompleteOption['description']
+    renderExtraDiffs?: (
+      viewMode: ViewMode,
+      previewPlaceholder?: IdAutocompleteOption,
+      currentOption?: IdAutocompleteOption
+    ) => React.ReactNode
   }
 
 export type { IdAutocompleteOption, IdAutocompleteProps }

--- a/src/scalars/components/fragments/id-autocomplete/use-id-autocomplete.ts
+++ b/src/scalars/components/fragments/id-autocomplete/use-id-autocomplete.ts
@@ -196,8 +196,8 @@ export function useIdAutocomplete({
 
         // Get current input element and selection positions
         const input = e.currentTarget
-        const start = input.selectionStart || 0
-        const end = input.selectionEnd || 0
+        const start = input.selectionStart ?? 0
+        const end = input.selectionEnd ?? 0
 
         // Create new value by inserting trimmed text at cursor position
         const currentValue = input.value

--- a/src/ui/components/data-entry/aid-input/__snapshots__/aid-input.test.tsx.snap
+++ b/src/ui/components/data-entry/aid-input/__snapshots__/aid-input.test.tsx.snap
@@ -1,0 +1,53 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AIDInput Component > should match snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="flex flex-col gap-2"
+  >
+    <label
+      class="inline-flex items-center text-sm font-medium leading-4 text-gray-900 dark:text-gray-50 mb-[3px]"
+      for=":r0:-aid"
+    >
+      AID Input
+    </label>
+    <div
+      class="flex size-full flex-col rounded-md [&_[cmdk-label]]:hidden dark:bg-charcoal-900 bg-gray-100"
+      cmdk-root=""
+      tabindex="-1"
+    >
+      <label
+        cmdk-label=""
+        for="radix-:r5:"
+        id="radix-:r4:"
+        style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0px;"
+      />
+      <div
+        class="group relative"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-controls="radix-:r3:"
+          aria-expanded="false"
+          aria-invalid="false"
+          aria-labelledby="radix-:r4:"
+          autocomplete="off"
+          autocorrect="off"
+          class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-9"
+          cmdk-input=""
+          id=":r0:-aid"
+          name="aid"
+          placeholder="did:ethr:"
+          role="combobox"
+          spellcheck="false"
+          type="text"
+          value=""
+        />
+        <div
+          class="absolute right-3 top-1/2 flex size-4 -translate-y-1/2 items-center pointer-events-none"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/ui/components/data-entry/aid-input/aid-input.stories.tsx
+++ b/src/ui/components/data-entry/aid-input/aid-input.stories.tsx
@@ -10,19 +10,12 @@ import { fetchOptions, fetchSelectedOption, mockedOptions } from './mocks.js'
 
 /**
  * The `AIDInput` component provides an input field for Agent IDs (typically DIDs).
- * It supports multiple configuration properties like:
- * - label
- * - description
- * - autoComplete
- * - fetchOptionsCallback
- * - fetchSelectedOptionCallback
- * - previewPlaceholder
- * - variant
  *
  * Features include:
  * - Multiple display variants for autocomplete options
  * - Copy paste support
  * - Async and sync options fetching
+ * - Customizable preview placeholder with icon, title, path, description and agent type
  *
  * > **Note:** This component does not have built-in validation. If you need built-in validation
  * > you can use the [AIDField](?path=/docs/scalars-aid-field--readme)
@@ -122,6 +115,16 @@ const meta: Meta<typeof AIDInput> = {
       if: { arg: 'autoComplete', neq: false },
     },
 
+    initialOptions: {
+      control: 'object',
+      description: 'Array of options to initially populate the autocomplete dropdown',
+      table: {
+        type: { summary: 'AIDOption[]' },
+        category: StorybookControlCategory.COMPONENT_SPECIFIC,
+      },
+      if: { arg: 'autoComplete', neq: false },
+    },
+
     previewPlaceholder: {
       control: 'object',
       description:
@@ -153,6 +156,49 @@ const meta: Meta<typeof AIDInput> = {
         category: StorybookControlCategory.COMPONENT_SPECIFIC,
       },
       if: { arg: 'autoComplete', neq: false },
+    },
+
+    ...PrebuiltArgTypes.viewMode,
+    ...PrebuiltArgTypes.baseValue,
+    basePreviewIcon: {
+      control: 'object',
+      description: 'The icon of the base preview',
+      table: {
+        type: { summary: 'IconName | React.ReactElement' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewTitle: {
+      control: 'text',
+      description: 'The title of the base preview',
+      table: {
+        type: { summary: 'string' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewPath: {
+      control: 'object',
+      description: 'The path of the base preview',
+      table: {
+        type: { summary: 'string | { text: string; url: string; }' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewDescription: {
+      control: 'text',
+      description: 'The description of the base preview',
+      table: {
+        type: { summary: 'string' },
+        category: StorybookControlCategory.DIFF,
+      },
+    },
+    basePreviewAgentType: {
+      control: 'text',
+      description: 'The agent type of the base preview',
+      table: {
+        type: { summary: 'string' },
+        category: StorybookControlCategory.DIFF,
+      },
     },
   },
   args: {
@@ -207,5 +253,71 @@ export const Filled: Story = {
     variant: 'withValueTitleAndDescription',
     fetchOptionsCallback: fetchOptions,
     fetchSelectedOptionCallback: fetchSelectedOption,
+  },
+}
+
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'AID input addition',
+    placeholder: 'did:ethr:',
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'addition',
+    baseValue: 'did:ethr:0xabcde14089478a327f09197987f16f9e5d936e8a',
+    basePreviewIcon: 'Person',
+    basePreviewTitle: 'Old Agent A',
+    basePreviewPath: {
+      text: 'old-renown.id/0xb9c5714089478a327f09197987f16f9e5d936e8a',
+      url: 'https://www.old-renown.id/',
+    },
+    basePreviewDescription: 'Old Agent A description',
+    basePreviewAgentType: 'Old Human Contributor',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'AID input removal',
+    placeholder: 'did:ethr:',
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'removal',
+    baseValue: 'did:ethr:0xabcde14089478a327f09197987f16f9e5d936e8a',
+    basePreviewIcon: 'Person',
+    basePreviewTitle: 'Old Agent A',
+    basePreviewPath: {
+      text: 'old-renown.id/0xb9c5714089478a327f09197987f16f9e5d936e8a',
+      url: 'https://www.old-renown.id/',
+    },
+    basePreviewDescription: 'Old Agent A description',
+    basePreviewAgentType: 'Old Human Contributor',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'AID input mixed',
+    placeholder: 'did:ethr:',
+    variant: 'withValueTitleAndDescription',
+    fetchOptionsCallback: fetchOptions,
+    fetchSelectedOptionCallback: fetchSelectedOption,
+    defaultValue: mockedOptions[0].value,
+    initialOptions: mockedOptions,
+    viewMode: 'mixed',
+    baseValue: 'did:ethr:0xabcde14089478a327f09197987f16f9e5d936e8a',
+    basePreviewIcon: 'Person',
+    basePreviewTitle: 'Old Agent A',
+    basePreviewPath: {
+      text: 'old-renown.id/0xb9c5714089478a327f09197987f16f9e5d936e8a',
+      url: 'https://www.old-renown.id/',
+    },
+    basePreviewDescription: 'Old Agent A description',
+    basePreviewAgentType: 'Old Human Contributor',
   },
 }

--- a/src/ui/components/data-entry/aid-input/aid-input.test.tsx
+++ b/src/ui/components/data-entry/aid-input/aid-input.test.tsx
@@ -1,0 +1,409 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { AIDInput } from './aid-input.js'
+
+describe('AIDInput Component', () => {
+  const mockedOptions = [
+    {
+      icon: 'Person' as const,
+      title: 'Agent A',
+      path: {
+        text: 'renown.id/0xb9c5714089478a327f09197987f16f9e5d936e8a',
+        url: 'https://www.renown.id/',
+      },
+      value: 'did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a',
+      description: 'Agent A description',
+      agentType: 'Human Contributor',
+    },
+    {
+      icon: 'Person' as const,
+      title: 'Agent B',
+      path: {
+        text: 'renown.id/0x5:0xb9c5714089478a327f09197987f16f9e5d936e8a',
+        url: 'https://www.renown.id/',
+      },
+      value: 'did:ethr:0x5:0xb9c5714089478a327f09197987f16f9e5d936e8a',
+      description: 'Agent B description',
+      agentType: 'Contributor Team',
+    },
+  ]
+
+  const defaultGetOptions = vi.fn().mockResolvedValue(mockedOptions)
+  const defaultGetSelectedOption = vi.fn().mockImplementation((value: string) => {
+    return mockedOptions.find((option) => option.value === value)
+  })
+
+  it('should match snapshot', () => {
+    const { asFragment } = render(
+      <AIDInput
+        name="aid"
+        label="AID Input"
+        placeholder="did:ethr:"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should render with label', () => {
+    render(
+      <AIDInput
+        name="aid"
+        label="Test Label"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+    expect(screen.getByText('Test Label')).toBeInTheDocument()
+  })
+
+  it('should render with description', () => {
+    render(
+      <AIDInput
+        name="aid"
+        label="Test Label"
+        description="Test Description"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+    expect(screen.getByText('Test Description')).toBeInTheDocument()
+  })
+
+  it('should handle disabled state', () => {
+    render(
+      <AIDInput
+        name="aid"
+        label="Test Label"
+        disabled
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+    expect(screen.getByRole('combobox')).toBeDisabled()
+  })
+
+  it('should display error messages', async () => {
+    render(
+      <AIDInput
+        name="aid"
+        label="Test Label"
+        errors={['Invalid AID format']}
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Invalid AID format')).toBeInTheDocument()
+    })
+  })
+
+  it('should display warning messages', () => {
+    render(
+      <AIDInput
+        name="aid"
+        label="Test Label"
+        warnings={['AID may be deprecated']}
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+    expect(screen.getByText('AID may be deprecated')).toBeInTheDocument()
+  })
+
+  it('should show autocomplete options', async () => {
+    const user = userEvent.setup()
+    const originalRandom = Math.random
+    Math.random = vi.fn().mockReturnValue(1)
+
+    render(
+      <AIDInput
+        name="aid"
+        label="Test Label"
+        variant="withValueTitleAndDescription"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, 'test')
+
+    await waitFor(() => {
+      expect(defaultGetOptions).toHaveBeenCalledWith('test', {
+        supportedNetworks: undefined,
+      })
+    })
+
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'true')
+      expect(screen.getByText(mockedOptions[0].title)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[1].title)).toBeInTheDocument()
+    })
+
+    Math.random = originalRandom
+  })
+
+  it('should have correct ARIA attributes', async () => {
+    render(
+      <AIDInput
+        name="aid"
+        label="Test Label"
+        required
+        errors={['Error message']}
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    expect(input).toHaveAttribute('aria-required', 'true')
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-invalid', 'true')
+    })
+    expect(input).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('should show correct placeholders for different variants', () => {
+    const { rerender } = render(
+      <AIDInput
+        name="aid"
+        label="Test Label"
+        variant="withValueTitleAndDescription"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+
+    expect(screen.getByText('Title not available')).toBeInTheDocument()
+    expect(screen.getByText('URL not available')).toBeInTheDocument()
+    expect(screen.getByText('Description not available')).toBeInTheDocument()
+    expect(screen.getByText('Agent type not available')).toBeInTheDocument()
+
+    rerender(
+      <AIDInput
+        name="aid"
+        label="Test Label"
+        variant="withValueAndTitle"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+
+    expect(screen.getByText('Title not available')).toBeInTheDocument()
+    expect(screen.getByText('URL not available')).toBeInTheDocument()
+    expect(screen.queryByText('Description not available')).not.toBeInTheDocument()
+    expect(screen.queryByText('Agent type not available')).not.toBeInTheDocument()
+
+    rerender(
+      <AIDInput
+        name="aid"
+        label="Test Label"
+        variant="withValue"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+
+    expect(screen.queryByText('Title not available')).not.toBeInTheDocument()
+    expect(screen.queryByText('URL not available')).not.toBeInTheDocument()
+    expect(screen.queryByText('Description not available')).not.toBeInTheDocument()
+    expect(screen.queryByText('Agent type not available')).not.toBeInTheDocument()
+  })
+
+  it('should handle autoComplete disabled', () => {
+    render(<AIDInput name="aid" label="Test Label" autoComplete={false} />)
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('should handle value changes and auto selection', async () => {
+    const user = userEvent.setup()
+    const originalRandom = Math.random
+    Math.random = vi.fn().mockReturnValue(1)
+
+    render(
+      <AIDInput
+        name="aid"
+        label="Test Label"
+        variant="withValueTitleAndDescription"
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    await user.click(input)
+    await user.type(input, mockedOptions[0].value)
+
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(mockedOptions[0].title)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].path.text)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].description)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].agentType)).toBeInTheDocument()
+    })
+
+    Math.random = originalRandom
+  })
+
+  it('should not invoke onChange on mount when it has a defaultValue', () => {
+    const onChange = vi.fn()
+    render(
+      <AIDInput
+        name="aid"
+        label="Test Label"
+        defaultValue={mockedOptions[0].value}
+        fetchOptionsCallback={defaultGetOptions}
+        fetchSelectedOptionCallback={defaultGetSelectedOption}
+        onChange={onChange}
+      />
+    )
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  // Tests for viewMode and diffs functionality
+  describe('viewMode and diffs', () => {
+    it('should render in edition mode by default', () => {
+      render(
+        <AIDInput
+          name="aid"
+          label="Test Label"
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
+    })
+
+    it('should render in edition mode when viewMode is explicitly set to edition', () => {
+      render(
+        <AIDInput
+          name="aid"
+          label="Test Label"
+          viewMode="edition"
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is addition', () => {
+      render(
+        <AIDInput
+          name="aid"
+          label="Test Label"
+          viewMode="addition"
+          value={mockedOptions[0].value}
+          baseValue={mockedOptions[1].value}
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].value)).toBeInTheDocument()
+      expect(screen.queryByText(mockedOptions[1].value)).not.toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is removal', () => {
+      render(
+        <AIDInput
+          name="aid"
+          label="Test Label"
+          viewMode="removal"
+          value={mockedOptions[0].value}
+          baseValue={mockedOptions[1].value}
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[1].value)).toBeInTheDocument()
+      expect(screen.queryByText(mockedOptions[0].value)).not.toBeInTheDocument()
+    })
+
+    it('should render diff component when viewMode is mixed', () => {
+      render(
+        <AIDInput
+          name="aid"
+          label="Test Label"
+          viewMode="mixed"
+          value={mockedOptions[0].value}
+          baseValue={mockedOptions[1].value}
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].value)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[1].value)).toBeInTheDocument()
+    })
+
+    it('should pass correct props to diff component', () => {
+      render(
+        <AIDInput
+          name="aid"
+          label="Test Label"
+          viewMode="mixed"
+          value={mockedOptions[0].value}
+          baseValue={mockedOptions[1].value}
+          required
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('*')).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].value)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[1].value)).toBeInTheDocument()
+    })
+
+    it('should handle empty value in diff mode', () => {
+      const { container } = render(
+        <AIDInput
+          name="aid"
+          label="Test Label"
+          viewMode="addition"
+          value=""
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      const diffSpans = container.querySelectorAll('span')
+      diffSpans.forEach((span) => {
+        expect(span).toHaveTextContent('')
+      })
+    })
+
+    it('should respect variant in diff mode', () => {
+      render(
+        <AIDInput
+          name="aid"
+          label="Test Label"
+          viewMode="addition"
+          value={mockedOptions[0].value}
+          initialOptions={mockedOptions}
+          variant="withValueTitleAndDescription"
+          fetchOptionsCallback={defaultGetOptions}
+          fetchSelectedOptionCallback={defaultGetSelectedOption}
+        />
+      )
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].value)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].title)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].path.text)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].description)).toBeInTheDocument()
+      expect(screen.getByText(mockedOptions[0].agentType)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/ui/components/data-entry/aid-input/aid-input.tsx
+++ b/src/ui/components/data-entry/aid-input/aid-input.tsx
@@ -2,7 +2,10 @@ import React, { useCallback, useId, useMemo } from 'react'
 import { IdAutocompleteContext } from '../../../../scalars/components/fragments/id-autocomplete/id-autocomplete-context.js'
 import { IdAutocompleteListOption } from '../../../../scalars/components/fragments/id-autocomplete/id-autocomplete-list-option.js'
 import { IdAutocomplete } from '../../../../scalars/components/fragments/id-autocomplete/index.js'
+import { TextDiff } from '../input/subcomponent/text-diff.js'
+import { cn } from '../../../../scalars/lib/index.js'
 import type { AIDInputProps, AIDOption } from './types.js'
+import type { ViewMode } from '../../../../scalars/components/types.js'
 
 const AIDInput = React.forwardRef<HTMLInputElement, AIDInputProps>(
   (
@@ -30,8 +33,9 @@ const AIDInput = React.forwardRef<HTMLInputElement, AIDInputProps>(
       fetchOptionsCallback,
       fetchSelectedOptionCallback,
       isOpenByDefault, // to be used only in stories
-      initialOptions, // to be used only in stories
+      initialOptions,
       previewPlaceholder,
+      basePreviewAgentType,
       ...props
     },
     ref
@@ -60,21 +64,69 @@ const AIDInput = React.forwardRef<HTMLInputElement, AIDInputProps>(
           title={option.title}
           path={
             displayProps?.asPlaceholder
-              ? previewPlaceholder?.path || 'URL not available'
-              : option.path || 'URL not available'
+              ? (previewPlaceholder?.path ?? 'URL not available')
+              : (option.path ?? 'URL not available')
           }
-          value={displayProps?.asPlaceholder ? previewPlaceholder?.value || 'aid not available' : option.value}
+          value={displayProps?.asPlaceholder ? (previewPlaceholder?.value ?? 'aid not available') : option.value}
           description={option.description}
           agentType={
             displayProps?.asPlaceholder
-              ? previewPlaceholder?.agentType || 'Agent type not available'
-              : option.agentType || 'Agent type not available'
+              ? (previewPlaceholder?.agentType ?? 'Agent type not available')
+              : (option.agentType ?? 'Agent type not available')
           }
-          placeholderIcon={previewPlaceholder?.icon || 'Person'}
+          placeholderIcon={previewPlaceholder?.icon ?? 'Person'}
           {...displayProps}
         />
       ),
       [variant, previewPlaceholder]
+    )
+
+    const renderAgentTypeDiffs = useCallback(
+      (viewMode: ViewMode, previewPlaceholder?: AIDOption, currentOption?: AIDOption) => {
+        const previewPlaceholderAgentType = previewPlaceholder?.agentType ?? 'Agent type not available'
+        const previewAgentType = currentOption?.agentType
+
+        return basePreviewAgentType !== undefined || previewAgentType !== undefined ? (
+          <div className={cn('grid w-full', viewMode === 'mixed' && 'grid-cols-2 gap-4')}>
+            <div className={cn('flex w-full flex-col overflow-hidden', viewMode === 'mixed' && 'pr-1')}>
+              {((viewMode === 'removal' || viewMode === 'mixed') &&
+                (basePreviewAgentType === '' || basePreviewAgentType === undefined)) ||
+              (viewMode === 'addition' && (previewAgentType === '' || previewAgentType === undefined)) ? (
+                <span className={cn('w-full text-right truncate text-xs leading-5 text-gray-400')}>
+                  {previewPlaceholderAgentType}
+                </span>
+              ) : (
+                <TextDiff
+                  baseValue={basePreviewAgentType}
+                  value={previewAgentType ?? ''}
+                  viewMode={viewMode === 'mixed' ? 'removal' : viewMode}
+                  diffMode="sentences"
+                  className={cn('w-full text-right truncate text-xs leading-5 text-gray-500')}
+                />
+              )}
+            </div>
+
+            {viewMode === 'mixed' && (
+              <div className={cn('flex w-full flex-col overflow-hidden pl-1')}>
+                {previewAgentType === '' || previewAgentType === undefined ? (
+                  <span className={cn('w-full text-right truncate text-xs leading-5 text-gray-400')}>
+                    {previewPlaceholderAgentType}
+                  </span>
+                ) : (
+                  <TextDiff
+                    baseValue={basePreviewAgentType}
+                    value={previewAgentType}
+                    viewMode="addition"
+                    diffMode="sentences"
+                    className={cn('w-full text-right truncate text-xs leading-5 text-gray-500')}
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        ) : null
+      },
+      [basePreviewAgentType]
     )
 
     return (
@@ -106,6 +158,7 @@ const AIDInput = React.forwardRef<HTMLInputElement, AIDInputProps>(
             initialOptions={initialOptions}
             renderOption={renderOption}
             previewPlaceholder={previewPlaceholder}
+            renderExtraDiffs={renderAgentTypeDiffs}
             {...props}
             ref={ref}
           />

--- a/src/ui/components/data-entry/aid-input/types.ts
+++ b/src/ui/components/data-entry/aid-input/types.ts
@@ -8,19 +8,21 @@ interface Network {
   name?: string
 }
 
-interface AIDOptionProps {
+type AIDOption = IdAutocompleteOption & {
   agentType?: string
 }
 
-// TODO: fix this type
-// @ts-expect-error - this will be fixed soon
-type AIDOption = IdAutocompleteOption<AIDOptionProps>
-
 type AIDInputBaseProps = Omit<
   IdAutocompleteProps,
-  'autoComplete' | 'fetchOptionsCallback' | 'fetchSelectedOptionCallback' | 'previewPlaceholder' | 'renderOption'
+  | 'autoComplete'
+  | 'fetchOptionsCallback'
+  | 'fetchSelectedOptionCallback'
+  | 'previewPlaceholder'
+  | 'renderOption'
+  | 'renderExtraDiffs'
 > & {
   supportedNetworks?: Network[]
+  basePreviewAgentType?: string
 }
 
 type AIDInputProps = AIDInputBaseProps &

--- a/src/ui/components/data-entry/currency-code-picker/currency-code-picker.stories.tsx
+++ b/src/ui/components/data-entry/currency-code-picker/currency-code-picker.stories.tsx
@@ -106,6 +106,8 @@ const meta: Meta<typeof CurrencyCodePicker> = {
         showErrorOnChange: false,
       },
     }),
+    ...PrebuiltArgTypes.viewMode,
+    ...PrebuiltArgTypes.baseValue,
   },
 
   args: {

--- a/src/ui/components/data-entry/oid-input/types.ts
+++ b/src/ui/components/data-entry/oid-input/types.ts
@@ -15,7 +15,12 @@ type OIDOption = IdAutocompleteOption
 
 type OIDInputBaseProps = Omit<
   IdAutocompleteProps,
-  'autoComplete' | 'fetchOptionsCallback' | 'fetchSelectedOptionCallback' | 'previewPlaceholder' | 'renderOption'
+  | 'autoComplete'
+  | 'fetchOptionsCallback'
+  | 'fetchSelectedOptionCallback'
+  | 'previewPlaceholder'
+  | 'renderOption'
+  | 'renderExtraDiffs'
 >
 
 type OIDInputProps = OIDInputBaseProps &

--- a/src/ui/components/data-entry/phid-input/types.ts
+++ b/src/ui/components/data-entry/phid-input/types.ts
@@ -15,7 +15,12 @@ type PHIDOption = IdAutocompleteOption
 
 type PHIDInputBaseProps = Omit<
   IdAutocompleteProps,
-  'autoComplete' | 'fetchOptionsCallback' | 'fetchSelectedOptionCallback' | 'previewPlaceholder' | 'renderOption'
+  | 'autoComplete'
+  | 'fetchOptionsCallback'
+  | 'fetchSelectedOptionCallback'
+  | 'previewPlaceholder'
+  | 'renderOption'
+  | 'renderExtraDiffs'
 > &
   (
     | {


### PR DESCRIPTION
## Ticket
https://trello.com/c/xfUYBkwa/1059-create-a-read-only-diff-status-for-the-aid-component

## Description
- Should add tests to AIDInput.
- Should add the necessary props and types to display the new status.
- Should the new status allow to see the diff given the additions and removals.