### PR TITLE
feat(scalars): add new format for the date-picker-component

### DIFF
--- a/src/scalars/components/date-time-picker-field/date-time-picker-field.stories.tsx
+++ b/src/scalars/components/date-time-picker-field/date-time-picker-field.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { FORMAT_MAPPING } from '../../../ui/components/data-entry/date-time-picker/utils.js'
+import { FORMAT_MAPPING_DATE_TIME_PICKER } from '../../../ui/components/data-entry/date-time-picker/utils.js'
 import { withForm } from '../../index.js'
 import { getDefaultArgTypes, getValidationArgTypes, StorybookControlCategory } from '../../lib/storybook-arg-types.js'
 import { DateTimePickerField } from './date-time-picker-field.js'
@@ -66,7 +66,7 @@ const meta: Meta<typeof DateTimePickerField> = {
         type: 'select',
       },
       description: 'The format of the date in the date picker',
-      options: Object.keys(FORMAT_MAPPING),
+      options: Object.keys(FORMAT_MAPPING_DATE_TIME_PICKER),
       table: {
         defaultValue: { summary: 'YYYY-MM-DD' },
         type: {

--- a/src/ui/components/data-entry/date-picker/date-picker.test.tsx
+++ b/src/ui/components/data-entry/date-picker/date-picker.test.tsx
@@ -252,4 +252,28 @@ describe('DatePicker', () => {
       expect(screen.queryByTestId('date-picker-diff')).not.toBeInTheDocument()
     })
   })
+  it('should show year only years when format is YYYY', async () => {
+    const date = new Date()
+    const year = date.getFullYear().toString()
+    render(<DatePicker {...defaultProps} dateFormat="YYYY" />)
+
+    const calendarTrigger = screen.getByTestId('icon-fallback')
+    await userEvent.click(calendarTrigger)
+
+    expect(screen.getAllByText(year)).toHaveLength(2)
+    expect(screen.queryByText('January')).not.toBeInTheDocument()
+  })
+  it('should show year and month only when format is YYYY-MM', async () => {
+    const date = new Date()
+    const year = date.getFullYear().toString()
+    const month = date.toLocaleString('en-US', { month: 'long' })
+
+    render(<DatePicker {...defaultProps} dateFormat="YYYY-MM" />)
+
+    const calendarTrigger = screen.getByTestId('icon-fallback')
+    await userEvent.click(calendarTrigger)
+
+    expect(screen.getAllByText(year)).toHaveLength(2)
+    expect(screen.getByText(month)).toBeInTheDocument()
+  })
 })

--- a/src/ui/components/data-entry/date-picker/date-picker.tsx
+++ b/src/ui/components/data-entry/date-picker/date-picker.tsx
@@ -15,7 +15,7 @@ import DateInputDiff from './subcomponents/date-picker-diff/date-picker-diff.js'
 
 interface DatePickerProps
   extends InputBaseProps<DateFieldValue>,
-    Omit<CalendarProps, 'mode'>,
+    Omit<CalendarProps, 'mode' | 'handleCalendarMonthYearSelect'>,
     WithDifference<DateFieldValue> {
   label?: string
   id?: string
@@ -82,6 +82,7 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
       disabledDates,
       weekStartDay,
       handleDayClick,
+      handleCalendarMonthYearSelect,
     } = useDatePickerField({
       value,
       defaultValue,
@@ -131,6 +132,8 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
             <Calendar
               mode="single"
               selected={date}
+              dateFormat={dateFormat}
+              handleCalendarMonthYearSelect={handleCalendarMonthYearSelect}
               weekStartsOn={weekStartDay}
               onSelect={handleDateSelect}
               disabled={disabledDates}

--- a/src/ui/components/data-entry/date-picker/subcomponents/calendar/calendar.tsx
+++ b/src/ui/components/data-entry/date-picker/subcomponents/calendar/calendar.tsx
@@ -15,6 +15,7 @@ import type { DatePickerView } from '../../types.js'
 import { NavCalendar } from '../calendar-nav/calendar-nav.js'
 import { CaptionLabel } from '../caption-label/caption-label.js'
 import { MonthGrid } from '../month-grid.js'
+import { getCalendarType } from '../../../date-time-picker/utils.js'
 
 const Chevron = (props: {
   className?: string
@@ -70,6 +71,8 @@ export type CalendarProps = DayPickerProps & {
   dayPickerClassName?: string
   disabledDates?: boolean
   className?: string
+  dateFormat?: string
+  handleCalendarMonthYearSelect: (year: number, monthIndex: number) => void
 }
 
 /**
@@ -85,9 +88,12 @@ const Calendar = ({
   yearRange = 12,
   numberOfMonths,
   disabledDates = false,
+  dateFormat,
+  handleCalendarMonthYearSelect,
   ...props
 }: CalendarProps) => {
-  const [navView, setNavView] = React.useState<DatePickerView>('days')
+  const startNavView = getCalendarType(dateFormat ?? '')
+  const [navView, setNavView] = React.useState<DatePickerView>(startNavView)
   const [displayYears, setDisplayYears] = React.useState<{
     from: number
     to: number
@@ -200,21 +206,38 @@ const Calendar = ({
         />
       )
     },
-    [navView, displayYears, setDisplayYears, startMonth, endMonth, _buttonPreviousClassName, _buttonNextClassName]
+    [navView, displayYears, startMonth, endMonth, _buttonPreviousClassName, _buttonNextClassName]
   )
 
   const createCaptionLabel = React.useCallback(
     (props: CaptionLabelProps) => {
-      return <CaptionLabel {...props} showYearSwitcher={showYearSwitcher} navView={navView} setNavView={setNavView} />
+      return (
+        <CaptionLabel
+          {...props}
+          showYearSwitcher={showYearSwitcher}
+          navView={navView}
+          setNavView={setNavView}
+          dateFormat={dateFormat}
+        />
+      )
     },
-    [navView, showYearSwitcher]
+    [dateFormat, navView, showYearSwitcher]
   )
 
   const createMonthGrid = React.useCallback(
     (props: MonthGridProps) => {
-      return <MonthGrid navView={navView} displayYears={displayYears} setNavView={setNavView} {...props} />
+      return (
+        <MonthGrid
+          navView={navView}
+          displayYears={displayYears}
+          setNavView={setNavView}
+          dateFormat={dateFormat}
+          handleCalendarMonthYearSelect={handleCalendarMonthYearSelect}
+          {...props}
+        />
+      )
     },
-    [displayYears, navView]
+    [dateFormat, displayYears, handleCalendarMonthYearSelect, navView]
   )
   return (
     <DayPicker

--- a/src/ui/components/data-entry/date-picker/subcomponents/caption-label/caption-label.tsx
+++ b/src/ui/components/data-entry/date-picker/subcomponents/caption-label/caption-label.tsx
@@ -8,10 +8,13 @@ interface CaptionLabelProps extends HTMLAttributes<HTMLSpanElement> {
   showYearSwitcher: boolean
   navView: DatePickerView
   setNavView: (navView: DatePickerView) => void
+  dateFormat?: string
 }
 
 const CaptionLabel = (props: CaptionLabelProps): JSX.Element => {
-  const { children, showYearSwitcher, navView, setNavView, ...rest } = props
+  const { children, showYearSwitcher, navView, setNavView, dateFormat, ...rest } = props
+  const isHiddenMonthButton = dateFormat !== 'YYYY'
+  const navigateTo = ['YYYY-MM', 'MMM-YYYY', 'MMM-YYYY'].includes(dateFormat ?? '')
 
   if (!showYearSwitcher) return <span {...rest}>{children}</span>
 
@@ -30,10 +33,12 @@ const CaptionLabel = (props: CaptionLabelProps): JSX.Element => {
           setNavView('years')
         }}
       >
-        <span className={cn(isSelectedMonth ? 'text-gray-900' : 'text-gray-600')}>{monthAbbreviation}</span>
+        {isHiddenMonthButton && (
+          <span className={cn(isSelectedMonth ? 'text-gray-900' : 'text-gray-600')}>{monthAbbreviation}</span>
+        )}
         <span className={cn(isSelectedYear ? 'text-gray-900' : 'text-gray-600')}>{yearNumber}</span>
       </Button>
-      {navView === 'days' ? (
+      {navView === 'days' && (
         <Icon
           className="size-[18px] cursor-pointer text-gray-600"
           name="TriangleDown"
@@ -41,11 +46,12 @@ const CaptionLabel = (props: CaptionLabelProps): JSX.Element => {
             setNavView('years')
           }}
         />
-      ) : (
+      )}
+      {navView !== 'days' && isHiddenMonthButton && (
         <Button
           variant="ghost"
           onClick={() => {
-            setNavView('days')
+            setNavView(navigateTo ? 'years' : 'days')
           }}
         >
           <Icon className="size-[18px] text-gray-900" name="CrossCircle" />

--- a/src/ui/components/data-entry/date-picker/subcomponents/month-grid.tsx
+++ b/src/ui/components/data-entry/date-picker/subcomponents/month-grid.tsx
@@ -7,6 +7,7 @@ import type { PropsWithChildren } from 'react'
 import { format } from 'date-fns'
 import { MONTHS } from './utils.js'
 import { cn } from '../../../../../scalars/lib/utils.js'
+import { getDateFormat } from '../../date-time-picker/utils.js'
 
 interface Props extends PropsWithChildren<MonthGridProps> {
   navView: DatePickerView
@@ -14,6 +15,8 @@ interface Props extends PropsWithChildren<MonthGridProps> {
   startMonth?: Date
   endMonth?: Date
   setNavView: (view: DatePickerView) => void
+  dateFormat?: string
+  handleCalendarMonthYearSelect: (year: number, monthIndex: number) => void
 }
 const MonthGrid = ({
   navView,
@@ -23,12 +26,72 @@ const MonthGrid = ({
   setNavView,
   className,
   children,
+  dateFormat,
+  handleCalendarMonthYearSelect,
   ...props
 }: Props) => {
   const { goToMonth, months } = useDayPicker()
-
+  const internalFormat = getDateFormat(dateFormat ?? '')
+  const monthFormat = ['yyyy-MM', 'MM/yyyy', 'MM/yyyy', 'MMM-yyyy', 'YYYY'].includes(internalFormat ?? '')
+  const yearFormat = dateFormat === 'YYYY' && internalFormat === 'yyyy-MM-dd'
   const actualYear = format(months[0].date, 'yyyy')
   const actualMonth = format(months[0].date, 'MMMM')
+
+  if (yearFormat) {
+    return (
+      <div className={cn('mt-[18px] flex flex-col gap-2', 'date-picker__year-grid--view')}>
+        <YearGrid
+          displayYears={displayYears}
+          startMonth={startMonth}
+          endMonth={endMonth}
+          months={months}
+          currentYear={new Date().getFullYear()}
+          onYearSelect={(year) => {
+            handleCalendarMonthYearSelect(year, 0)
+          }}
+        />
+      </div>
+    )
+  }
+
+  if (monthFormat) {
+    if (navView === 'years') {
+      return (
+        <div className={cn('mt-[18px] flex flex-col gap-2', 'date-picker__year-grid--view')}>
+          <YearGrid
+            displayYears={displayYears}
+            startMonth={startMonth}
+            endMonth={endMonth}
+            months={months}
+            currentYear={new Date().getFullYear()}
+            onYearSelect={(year) => {
+              goToMonth(new Date(year, MONTHS.indexOf(actualMonth)))
+              setNavView('months')
+            }}
+          />
+          <div>
+            <CalendarDateFooter navView={navView} setNavView={setNavView} />
+          </div>
+        </div>
+      )
+    }
+    if (navView === 'months') {
+      return (
+        <div className={cn('mt-[15px] flex flex-col gap-3', 'date-picker__month-grid--view')}>
+          <MonthView
+            actualMonth={actualMonth}
+            actualYear={actualYear}
+            onMonthSelect={(year, monthIndex) => {
+              handleCalendarMonthYearSelect(year, monthIndex)
+            }}
+          />
+          <div>
+            <CalendarDateFooter navView={navView} setNavView={setNavView} />
+          </div>
+        </div>
+      )
+    }
+  }
   if (navView === 'years') {
     return (
       <div className={cn('mt-[18px] flex flex-col gap-2', 'date-picker__year-grid--view')}>

--- a/src/ui/components/data-entry/date-picker/use-date-picker.tsx
+++ b/src/ui/components/data-entry/date-picker/use-date-picker.tsx
@@ -1,4 +1,4 @@
-import { parse, startOfDay } from 'date-fns'
+import { format, parse, startOfDay } from 'date-fns'
 import React, { useCallback, useMemo } from 'react'
 
 import { getDateFormat, normalizeMonthFormat, parseDateValue, parseInputString } from '../date-time-picker/utils.js'
@@ -150,6 +150,15 @@ export const useDatePickerField = ({
     return fechaUTC
   }, [value, internalFormat])
 
+  const handleCalendarMonthYearSelect = (year: number, monthIndex: number) => {
+    const yearFormat = dateFormat === 'YYYY' && internalFormat === 'yyyy-MM-dd'
+    const newInputValue = format(new Date(year, monthIndex), internalFormat ?? 'yyyy-MM-dd')
+    const inputToShow = yearFormat ? `${year}` : newInputValue
+    setInputDisplay(inputToShow)
+    onChange?.(createChangeEvent(newInputValue))
+    setIsOpen(false)
+  }
+
   return {
     date,
     inputValue: inputDisplay,
@@ -161,5 +170,6 @@ export const useDatePickerField = ({
     disabledDates,
     weekStartDay,
     handleDayClick,
+    handleCalendarMonthYearSelect,
   }
 }

--- a/src/ui/components/data-entry/date-time-picker/date-time-picker.stories.tsx
+++ b/src/ui/components/data-entry/date-time-picker/date-time-picker.stories.tsx
@@ -6,7 +6,7 @@ import {
   StorybookControlCategory,
 } from '../../../../scalars/lib/storybook-arg-types'
 import { DateTimePicker } from './date-time-picker.js'
-import { FORMAT_MAPPING } from './utils.js'
+import { FORMAT_MAPPING_DATE_TIME_PICKER } from './utils.js'
 
 /**
  * The `DateTimePicker` component provides an input field for selecting both dates and times.
@@ -199,7 +199,7 @@ const meta: Meta<typeof DateTimePicker> = {
         type: 'select',
       },
       description: 'The format of the date in the date picker',
-      options: Object.keys(FORMAT_MAPPING),
+      options: Object.keys(FORMAT_MAPPING_DATE_TIME_PICKER),
       table: {
         defaultValue: { summary: 'YYYY-MM-DD' },
         type: {

--- a/src/ui/components/data-entry/date-time-picker/utils.ts
+++ b/src/ui/components/data-entry/date-time-picker/utils.ts
@@ -1,6 +1,16 @@
 import { format, isValid, parse } from 'date-fns'
 
-export const ALLOWED_FORMATS = ['yyyy-MM-dd', 'dd/MM/yyyy', 'MM/dd/yyyy', 'dd-MMM-yyyy', 'MMM-dd-yyyy']
+export const ALLOWED_FORMATS = [
+  'yyyy-MM-dd',
+  'dd/MM/yyyy',
+  'MM/dd/yyyy',
+  'dd-MMM-yyyy',
+  'MMM-dd-yyyy',
+  'yyyy-MM',
+  'MM/yyyy',
+  'MMM-yyyy',
+  'yyyy',
+]
 
 export const isFormatAllowed = (dateString: string) =>
   Object.values(dateFormatRegexes).some((regex) => regex.test(dateString))
@@ -17,6 +27,9 @@ export const dateFormatRegexes = {
   'MM/dd/yyyy': /^(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/\d{4}$/,
   'dd-MMM-yyyy': /^(0[1-9]|[12]\d|3[01])-(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{4}$/,
   'MMM-dd-yyyy': /^(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(0[1-9]|[12]\d|3[01])-\d{4}$/,
+  'yyyy-MM': /^\d{4}-(0[1-9]|1[0-2])$/,
+  'MM/yyyy': /^(0[1-9]|1[0-2])\/\d{4}$/,
+  'MMM-yyyy': /^(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{4}$/,
 }
 
 /**
@@ -146,7 +159,22 @@ export const createBlurEvent = (value: string): React.FocusEvent<HTMLInputElemen
   return nativeEvent as unknown as React.FocusEvent<HTMLInputElement>
 }
 
+// YYYY-MM .......................yyyy-MM
+// MM/YYYY........................MM/yyyy
+// MMM-YYYY.....................MMM-yyyy
+
 export const FORMAT_MAPPING = {
+  'YYYY-MM-DD': 'yyyy-MM-dd',
+  'DD/MM/YYYY': 'dd/MM/yyyy',
+  'MM/DD/YYYY': 'MM/dd/yyyy',
+  'DD-MMM-YYYY': 'dd-MMM-yyyy',
+  'MMM-DD-YYYY': 'MMM-dd-yyyy',
+  'YYYY-MM': 'yyyy-MM',
+  'MM/YYYY': 'MM/yyyy',
+  'MMM-YYYY': 'MMM-yyyy',
+  YYYY: 'yyyy',
+}
+export const FORMAT_MAPPING_DATE_TIME_PICKER = {
   'YYYY-MM-DD': 'yyyy-MM-dd',
   'DD/MM/YYYY': 'dd/MM/yyyy',
   'MM/DD/YYYY': 'MM/dd/yyyy',
@@ -166,6 +194,14 @@ export const getDateFormat = (displayFormat: string): string | undefined => {
       return 'dd-MMM-yyyy'
     case 'MMM-DD-YYYY':
       return 'MMM-dd-yyyy'
+    case 'YYYY-MM':
+      return 'yyyy-MM'
+    case 'MM/YYYY':
+      return 'MM/yyyy'
+    case 'MMM-YYYY':
+      return 'MMM-yyyy'
+    case 'YYYY':
+      return 'yyyy-MM-dd'
     default:
       return undefined
   }
@@ -218,4 +254,21 @@ export const parseDateValue = (dateValue: string | number | undefined) => {
   }
 
   return undefined
+}
+
+/**
+ * Determine the type of calendar to open based on the date format.
+ * @param dateFormat - The date format.
+ * @returns The type of calendar to open.
+ * @example
+ * getCalendarType('YYYY') // 'year'
+ * getCalendarType('YYYY-MM') // 'month'
+ * getCalendarType('YYYY-MM-DD') // 'day'
+ */
+
+export const getCalendarType = (dateFormat: string): 'years' | 'months' | 'days' => {
+  if (!dateFormat) return 'days'
+  const isDayFormat = ['YYYY-MM-DD', 'DD/MM/YYYY', 'MM/DD/YYYY', 'DD-MMM-YYYY', 'MMM-DD-YYYY'].includes(dateFormat)
+  if (isDayFormat) return 'days'
+  return 'years'
 }


### PR DESCRIPTION
## Ticket
- https://trello.com/c/HnZVa4UX/1063-add-month-year-and-year-only-selection-modes-to-the-datepicker

## Description
- Should support a mode that lets users pick only a month and a year.