### PR TITLE
fix(scalars): fix focus label and fix unnecessary props

### DIFF
--- a/src/scalars/components/date-picker-field/__snapshots__/date-picker-field.test.tsx.snap
+++ b/src/scalars/components/date-picker-field/__snapshots__/date-picker-field.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`DatePickerField > should match the snapshot 1`] = `
     >
       <label
         class="inline-flex items-center text-sm font-medium leading-4 text-gray-900 dark:text-gray-50 mb-[3px]"
+        for=":r1:"
       >
         Test Label
       </label>
@@ -21,7 +22,7 @@ exports[`DatePickerField > should match the snapshot 1`] = `
           class="flex w-full rounded-md text-sm focus-within:ring-ring dark:ring-charcoal-300 ring-gray-900 focus-within:ring-1 focus-within:ring-offset-0 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white focus:[&_.input-field]:bg-transparent dark:focus-within:hover:bg-charcoal-900 focus-within:hover:cursor-default focus-within:hover:bg-white base-picker__input [&.base-picker\\\\_\\\\_popover]:px-4 [&.base-picker\\\\_\\\\_popover]:pb-6 [&.base-picker\\\\_\\\\_popover]:pt-3 undefined"
         >
           <button
-            aria-controls="radix-:r1:"
+            aria-controls="radix-:r2:"
             aria-expanded="false"
             aria-haspopup="dialog"
             class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground pl-3 pr-2 z-1 focus:text-selected-foreground focus:bg-none button-ghost focus:outline-none focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:ring-gray-900"
@@ -54,8 +55,7 @@ exports[`DatePickerField > should match the snapshot 1`] = `
           <input
             class="flex h-9 rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-gray-900 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 w-full rounded-l-none border-none text-right placeholder:text-right input-field focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0"
             data-cast="DateString:yyyy-MM-dd"
-            errors=""
-            label="Test Label"
+            id=":r1:"
             name="test-date"
             value="2025-01-01"
           />

--- a/src/scalars/components/date-time-picker-field/__snapshots__/date-time-picker-field.test.tsx.snap
+++ b/src/scalars/components/date-time-picker-field/__snapshots__/date-time-picker-field.test.tsx.snap
@@ -54,8 +54,6 @@ exports[`DateTimePickerField > should match the snapshot 1`] = `
           <input
             class="flex h-9 rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-gray-900 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 w-full rounded-l-none border-none text-right placeholder:text-right input-field focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0"
             data-cast="DateTimeString:yyyy-MM-dd"
-            errors=""
-            label="Test Label"
             name="test-date"
             placeholder="Select date and time"
             value="2025-01-01 12:00"

--- a/src/scalars/components/time-picker-field/__snapshots__/time-picker-field.test.tsx.snap
+++ b/src/scalars/components/time-picker-field/__snapshots__/time-picker-field.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`TimePickerField > should match the snapshot 1`] = `
           class="flex w-full rounded-md text-sm focus-within:ring-ring dark:ring-charcoal-300 ring-gray-900 focus-within:ring-1 focus-within:ring-offset-0 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white focus:[&_.input-field]:bg-transparent dark:focus-within:hover:bg-charcoal-900 focus-within:hover:cursor-default focus-within:hover:bg-white base-picker__input [&.base-picker\\\\_\\\\_popover]:pr-3 [&.base-picker\\\\_\\\\_popover]:pb-4 [&.base-picker\\\\_\\\\_popover]:pl-4 [&.base-picker\\\\_\\\\_popover]:pt-3 undefined"
         >
           <button
-            aria-controls="radix-:r1:"
+            aria-controls="radix-:r2:"
             aria-expanded="false"
             aria-haspopup="dialog"
             class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground pl-3 pr-2 z-1 focus:text-selected-foreground focus:bg-none button-ghost focus:outline-none focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:ring-gray-900"
@@ -54,7 +54,7 @@ exports[`TimePickerField > should match the snapshot 1`] = `
           </button>
           <input
             class="flex h-9 rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-gray-900 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 w-full rounded-l-none border-none text-right placeholder:text-right input-field focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0"
-            errors=""
+            id="test-id"
             name="test-time"
             required=""
             value=""

--- a/src/ui/components/data-entry/date-picker/__snapshots__/date-picker.test.tsx.snap
+++ b/src/ui/components/data-entry/date-picker/__snapshots__/date-picker.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`DatePicker > should match the snapshot 1`] = `
   >
     <label
       class="inline-flex items-center text-sm font-medium leading-4 text-gray-900 dark:text-gray-50 mb-[3px]"
+      for=":r0:"
     >
       Test Label
     </label>
@@ -17,7 +18,7 @@ exports[`DatePicker > should match the snapshot 1`] = `
         class="flex w-full rounded-md text-sm focus-within:ring-ring dark:ring-charcoal-300 ring-gray-900 focus-within:ring-1 focus-within:ring-offset-0 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white focus:[&_.input-field]:bg-transparent dark:focus-within:hover:bg-charcoal-900 focus-within:hover:cursor-default focus-within:hover:bg-white base-picker__input [&.base-picker\\\\_\\\\_popover]:px-4 [&.base-picker\\\\_\\\\_popover]:pb-6 [&.base-picker\\\\_\\\\_popover]:pt-3 undefined"
       >
         <button
-          aria-controls="radix-:r0:"
+          aria-controls="radix-:r1:"
           aria-expanded="false"
           aria-haspopup="dialog"
           class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground pl-3 pr-2 z-1 focus:text-selected-foreground focus:bg-none button-ghost focus:outline-none focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:ring-gray-900"
@@ -50,7 +51,7 @@ exports[`DatePicker > should match the snapshot 1`] = `
         <input
           class="flex h-9 rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-gray-900 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 w-full rounded-l-none border-none text-right placeholder:text-right input-field focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0"
           data-cast="DateString:yyyy-MM-dd"
-          label="Test Label"
+          id=":r0:"
           name="test-date"
           value="2025-01-01"
         />

--- a/src/ui/components/data-entry/date-picker/date-picker.tsx
+++ b/src/ui/components/data-entry/date-picker/date-picker.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { forwardRef, useId } from 'react'
 import {
   FormDescription,
   FormGroup,
@@ -42,7 +42,7 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
   (
     {
       label,
-      id,
+      id: propId,
       errors,
       name,
       disabled,
@@ -96,6 +96,8 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
       minDate,
       maxDate,
     })
+    const generatedId = useId()
+    const id = propId ?? generatedId
 
     if (viewMode === 'edition') {
       return (
@@ -107,11 +109,9 @@ const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
           )}
           <BasePickerField
             ref={ref}
-            label={label}
             id={id}
             value={inputValue}
             name={name}
-            errors={errors}
             disabled={disabled}
             required={required}
             iconName="CalendarTime"

--- a/src/ui/components/data-entry/date-time-picker/__snapshots__/date-time-picker.test.tsx.snap
+++ b/src/ui/components/data-entry/date-time-picker/__snapshots__/date-time-picker.test.tsx.snap
@@ -50,7 +50,6 @@ exports[`DateTimePicker > should match the snapshot 1`] = `
         <input
           class="flex h-9 rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-gray-900 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 w-full rounded-l-none border-none text-right placeholder:text-right input-field focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0"
           data-cast="DateTimeString:yyyy-MM-dd"
-          label="Test Label"
           name="test-date"
           placeholder="Select date and time"
           value="2025-01-01 12:00"

--- a/src/ui/components/data-entry/date-time-picker/base-picker.tsx
+++ b/src/ui/components/data-entry/date-time-picker/base-picker.tsx
@@ -1,12 +1,12 @@
-import { forwardRef, type PropsWithChildren } from 'react'
+import type { PropsWithChildren } from 'react'
 import { Icon, type IconName } from '../../../components/icon/index.js'
 import { cn } from '../../../../scalars/lib/utils.js'
-import type { FieldErrorHandling, InputBaseProps } from '../../../../scalars/components/types.js'
+import type { InputBaseProps } from '../../../../scalars/components/types.js'
 import { Button } from '../../../../scalars/components/fragments/button/index.js'
 import { Popover, PopoverContent, PopoverTrigger } from '../../../../scalars/components/fragments/popover/index.js'
 import { Input } from '../../data-entry/input/input.js'
 
-export interface BasePickerFieldProps extends InputBaseProps<string>, FieldErrorHandling {
+export interface BasePickerFieldProps extends PropsWithChildren {
   id?: string
   name: string
   disabled?: boolean
@@ -26,110 +26,107 @@ export interface BasePickerFieldProps extends InputBaseProps<string>, FieldError
     'name' | 'onChange' | 'value' | 'defaultValue' | 'onBlur'
   >
   className?: string
+  ref?: React.Ref<HTMLInputElement>
 }
 
-const BasePickerField = forwardRef<HTMLInputElement, PropsWithChildren<BasePickerFieldProps>>(
-  (
-    {
-      id,
-      name,
-      disabled,
-      required,
-      iconName,
-      placeholder,
-      children,
-      value,
-      defaultValue,
-      isOpen,
-      setIsOpen,
-      onInputChange,
-      handleBlur,
-      inputProps,
-      className,
-      ...props
-    },
-    ref
-  ) => {
-    return (
-      <div className="flex flex-col space-y-2">
-        <div
-          className={cn(
-            'flex w-full rounded-md text-sm',
-            'focus-within:ring-ring dark:ring-charcoal-300 ring-gray-900 focus-within:ring-1 focus-within:ring-offset-0',
-            'dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white',
-            // focus
-            'focus:[&_.input-field]:bg-transparent',
-            'dark:focus-within:hover:bg-charcoal-900 focus-within:hover:cursor-default focus-within:hover:bg-white',
-            disabled &&
-              'dark:bg-charcoal-900 dark:hover:bg-charcoal-900 cursor-not-allowed bg-white hover:bg-transparent',
-            'base-picker__input',
-            className
-          )}
-        >
-          <Popover open={isOpen} onOpenChange={setIsOpen}>
-            <PopoverTrigger asChild>
-              <Button
-                variant="ghost"
-                disabled={disabled}
-                className={cn(
-                  'pl-3 pr-2',
-                  'z-1',
-                  'focus:text-selected-foreground focus:bg-none',
-                  'button-ghost',
-                  disabled && 'cursor-not-allowed hover:bg-transparent',
-                  'focus:outline-none focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:ring-gray-900'
-                )}
-                onClick={() => {
-                  if (!disabled) {
-                    setIsOpen(isOpen)
-                  }
-                }}
-              >
-                <Icon size={16} name={iconName} className="hover:none text-gray-700 dark:text-gray-50" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent
-              align="start"
+const BasePickerField = ({
+  id,
+  name,
+  disabled,
+  required,
+  iconName,
+  placeholder,
+  children,
+  value,
+  defaultValue,
+  isOpen,
+  setIsOpen,
+  onInputChange,
+  handleBlur,
+  inputProps,
+  className,
+  ref,
+  ...props
+}: BasePickerFieldProps) => {
+  return (
+    <div className="flex flex-col space-y-2">
+      <div
+        className={cn(
+          'flex w-full rounded-md text-sm',
+          'focus-within:ring-ring dark:ring-charcoal-300 ring-gray-900 focus-within:ring-1 focus-within:ring-offset-0',
+          'dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white',
+          // focus
+          'focus:[&_.input-field]:bg-transparent',
+          'dark:focus-within:hover:bg-charcoal-900 focus-within:hover:cursor-default focus-within:hover:bg-white',
+          disabled &&
+            'dark:bg-charcoal-900 dark:hover:bg-charcoal-900 cursor-not-allowed bg-white hover:bg-transparent',
+          'base-picker__input',
+          className
+        )}
+      >
+        <Popover open={isOpen} onOpenChange={setIsOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              disabled={disabled}
               className={cn(
-                'relative w-[275px]',
-                'border-gray-300 bg-white dark:border-gray-900 dark:bg-slate-600',
-                'rounded-lg',
-                'shadow-[0px_2px_4px_0px_rgba(0,0,0,0.08),0px_3px_10px_0px_rgba(0,0,0,0.10)]',
-                'mt-[14px]',
-                'dark:shadow-[1px_4px_15.3px_0px_#141921]',
-                '-translate-y-1',
-                'base-picker__popover',
-                className
+                'pl-3 pr-2',
+                'z-1',
+                'focus:text-selected-foreground focus:bg-none',
+                'button-ghost',
+                disabled && 'cursor-not-allowed hover:bg-transparent',
+                'focus:outline-none focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:ring-gray-900'
               )}
+              onClick={() => {
+                if (!disabled) {
+                  setIsOpen(isOpen)
+                }
+              }}
             >
-              {children}
-            </PopoverContent>
-          </Popover>
-          <Input
-            id={id}
-            name={name}
-            value={value}
-            onChange={onInputChange}
-            onBlur={handleBlur}
-            defaultValue={defaultValue}
+              <Icon size={16} name={iconName} className="hover:none text-gray-700 dark:text-gray-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
             className={cn(
-              'w-full rounded-l-none border-none text-right placeholder:text-right',
-              // focus
-              'input-field',
-              'focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0'
+              'relative w-[275px]',
+              'border-gray-300 bg-white dark:border-gray-900 dark:bg-slate-600',
+              'rounded-lg',
+              'shadow-[0px_2px_4px_0px_rgba(0,0,0,0.08),0px_3px_10px_0px_rgba(0,0,0,0.10)]',
+              'mt-[14px]',
+              'dark:shadow-[1px_4px_15.3px_0px_#141921]',
+              '-translate-y-1',
+              'base-picker__popover',
+              className
             )}
-            placeholder={placeholder}
-            ref={ref}
-            disabled={disabled}
-            required={required}
-            {...inputProps}
-            {...props}
-          />
-        </div>
+          >
+            {children}
+          </PopoverContent>
+        </Popover>
+        <Input
+          id={id}
+          name={name}
+          value={value}
+          onChange={onInputChange}
+          onBlur={handleBlur}
+          defaultValue={defaultValue}
+          className={cn(
+            'w-full rounded-l-none border-none text-right placeholder:text-right',
+            // focus
+            'input-field',
+            'focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0'
+          )}
+          placeholder={placeholder}
+          ref={ref}
+          disabled={disabled}
+          required={required}
+          {...inputProps}
+          {...props}
+        />
       </div>
-    )
-  }
-)
+    </div>
+  )
+}
 
 BasePickerField.displayName = 'BasePickerField'
 

--- a/src/ui/components/data-entry/date-time-picker/base-picker.tsx
+++ b/src/ui/components/data-entry/date-time-picker/base-picker.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren } from 'react'
+import { forwardRef, type PropsWithChildren } from 'react'
 import { Icon, type IconName } from '../../../components/icon/index.js'
 import { cn } from '../../../../scalars/lib/utils.js'
 import type { InputBaseProps } from '../../../../scalars/components/types.js'
@@ -26,107 +26,111 @@ export interface BasePickerFieldProps extends PropsWithChildren {
     'name' | 'onChange' | 'value' | 'defaultValue' | 'onBlur'
   >
   className?: string
-  ref?: React.Ref<HTMLInputElement>
+  children: React.ReactNode
 }
 
-const BasePickerField = ({
-  id,
-  name,
-  disabled,
-  required,
-  iconName,
-  placeholder,
-  children,
-  value,
-  defaultValue,
-  isOpen,
-  setIsOpen,
-  onInputChange,
-  handleBlur,
-  inputProps,
-  className,
-  ref,
-  ...props
-}: BasePickerFieldProps) => {
-  return (
-    <div className="flex flex-col space-y-2">
-      <div
-        className={cn(
-          'flex w-full rounded-md text-sm',
-          'focus-within:ring-ring dark:ring-charcoal-300 ring-gray-900 focus-within:ring-1 focus-within:ring-offset-0',
-          'dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white',
-          // focus
-          'focus:[&_.input-field]:bg-transparent',
-          'dark:focus-within:hover:bg-charcoal-900 focus-within:hover:cursor-default focus-within:hover:bg-white',
-          disabled &&
-            'dark:bg-charcoal-900 dark:hover:bg-charcoal-900 cursor-not-allowed bg-white hover:bg-transparent',
-          'base-picker__input',
-          className
-        )}
-      >
-        <Popover open={isOpen} onOpenChange={setIsOpen}>
-          <PopoverTrigger asChild>
-            <Button
-              variant="ghost"
-              disabled={disabled}
-              className={cn(
-                'pl-3 pr-2',
-                'z-1',
-                'focus:text-selected-foreground focus:bg-none',
-                'button-ghost',
-                disabled && 'cursor-not-allowed hover:bg-transparent',
-                'focus:outline-none focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:ring-gray-900'
-              )}
-              onClick={() => {
-                if (!disabled) {
-                  setIsOpen(isOpen)
-                }
-              }}
-            >
-              <Icon size={16} name={iconName} className="hover:none text-gray-700 dark:text-gray-50" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent
-            align="start"
-            className={cn(
-              'relative w-[275px]',
-              'border-gray-300 bg-white dark:border-gray-900 dark:bg-slate-600',
-              'rounded-lg',
-              'shadow-[0px_2px_4px_0px_rgba(0,0,0,0.08),0px_3px_10px_0px_rgba(0,0,0,0.10)]',
-              'mt-[14px]',
-              'dark:shadow-[1px_4px_15.3px_0px_#141921]',
-              '-translate-y-1',
-              'base-picker__popover',
-              className
-            )}
-          >
-            {children}
-          </PopoverContent>
-        </Popover>
-        <Input
-          id={id}
-          name={name}
-          value={value}
-          onChange={onInputChange}
-          onBlur={handleBlur}
-          defaultValue={defaultValue}
-          className={cn(
-            'w-full rounded-l-none border-none text-right placeholder:text-right',
-            // focus
-            'input-field',
-            'focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0'
-          )}
-          placeholder={placeholder}
+const BasePickerField = forwardRef<HTMLInputElement, BasePickerFieldProps>(
+  (
+    {
+      id,
+      name,
+      disabled,
+      required,
+      iconName,
+      placeholder,
+      children,
+      value,
+      defaultValue,
+      isOpen,
+      setIsOpen,
+      onInputChange,
+      handleBlur,
+      inputProps,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <div className="flex flex-col space-y-2">
+        <div
           ref={ref}
-          disabled={disabled}
-          required={required}
-          {...inputProps}
-          {...props}
-        />
+          className={cn(
+            'flex w-full rounded-md text-sm',
+            'focus-within:ring-ring dark:ring-charcoal-300 ring-gray-900 focus-within:ring-1 focus-within:ring-offset-0',
+            'dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white',
+            // focus
+            'focus:[&_.input-field]:bg-transparent',
+            'dark:focus-within:hover:bg-charcoal-900 focus-within:hover:cursor-default focus-within:hover:bg-white',
+            disabled &&
+              'dark:bg-charcoal-900 dark:hover:bg-charcoal-900 cursor-not-allowed bg-white hover:bg-transparent',
+            'base-picker__input',
+            className
+          )}
+        >
+          <Popover open={isOpen} onOpenChange={setIsOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                disabled={disabled}
+                className={cn(
+                  'pl-3 pr-2',
+                  'z-1',
+                  'focus:text-selected-foreground focus:bg-none',
+                  'button-ghost',
+                  disabled && 'cursor-not-allowed hover:bg-transparent',
+                  'focus:outline-none focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:ring-gray-900'
+                )}
+                onClick={() => {
+                  if (!disabled) {
+                    setIsOpen(isOpen)
+                  }
+                }}
+              >
+                <Icon size={16} name={iconName} className="hover:none text-gray-700 dark:text-gray-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="start"
+              className={cn(
+                'relative w-[275px]',
+                'border-gray-300 bg-white dark:border-gray-900 dark:bg-slate-600',
+                'rounded-lg',
+                'shadow-[0px_2px_4px_0px_rgba(0,0,0,0.08),0px_3px_10px_0px_rgba(0,0,0,0.10)]',
+                'mt-[14px]',
+                'dark:shadow-[1px_4px_15.3px_0px_#141921]',
+                '-translate-y-1',
+                'base-picker__popover',
+                className
+              )}
+            >
+              {children}
+            </PopoverContent>
+          </Popover>
+          <Input
+            id={id}
+            name={name}
+            value={value}
+            onChange={onInputChange}
+            onBlur={handleBlur}
+            defaultValue={defaultValue}
+            className={cn(
+              'w-full rounded-l-none border-none text-right placeholder:text-right',
+              // focus
+              'input-field',
+              'focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0'
+            )}
+            placeholder={placeholder}
+            disabled={disabled}
+            required={required}
+            {...inputProps}
+            {...props}
+          />
+        </div>
       </div>
-    </div>
-  )
-}
+    )
+  }
+)
 
 BasePickerField.displayName = 'BasePickerField'
 

--- a/src/ui/components/data-entry/date-time-picker/date-time-picker.tsx
+++ b/src/ui/components/data-entry/date-time-picker/date-time-picker.tsx
@@ -147,11 +147,9 @@ const DateTimePicker = forwardRef<HTMLInputElement, DateTimePickerProps>(
           ) : null}
           <BasePickerField
             ref={ref}
-            label={label}
             id={id}
             value={dateTimeToDisplay}
             name={name}
-            errors={errors}
             disabled={disabled}
             required={required}
             iconName="CalendarTime"

--- a/src/ui/components/data-entry/date-time-picker/utils.ts
+++ b/src/ui/components/data-entry/date-time-picker/utils.ts
@@ -159,10 +159,6 @@ export const createBlurEvent = (value: string): React.FocusEvent<HTMLInputElemen
   return nativeEvent as unknown as React.FocusEvent<HTMLInputElement>
 }
 
-// YYYY-MM .......................yyyy-MM
-// MM/YYYY........................MM/yyyy
-// MMM-YYYY.....................MMM-yyyy
-
 export const FORMAT_MAPPING = {
   'YYYY-MM-DD': 'yyyy-MM-dd',
   'DD/MM/YYYY': 'dd/MM/yyyy',

--- a/src/ui/components/data-entry/time-picker/__snapshots__/time-picker.test.tsx.snap
+++ b/src/ui/components/data-entry/time-picker/__snapshots__/time-picker.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`TimePicker > should render with basic props 1`] = `
         class="flex w-full rounded-md text-sm focus-within:ring-ring dark:ring-charcoal-300 ring-gray-900 focus-within:ring-1 focus-within:ring-offset-0 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white focus:[&_.input-field]:bg-transparent dark:focus-within:hover:bg-charcoal-900 focus-within:hover:cursor-default focus-within:hover:bg-white base-picker__input [&.base-picker\\\\_\\\\_popover]:pr-3 [&.base-picker\\\\_\\\\_popover]:pb-4 [&.base-picker\\\\_\\\\_popover]:pl-4 [&.base-picker\\\\_\\\\_popover]:pt-3 undefined"
       >
         <button
-          aria-controls="radix-:r0:"
+          aria-controls="radix-:r1:"
           aria-expanded="false"
           aria-haspopup="dialog"
           class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground pl-3 pr-2 z-1 focus:text-selected-foreground focus:bg-none button-ghost focus:outline-none focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:ring-gray-900"
@@ -50,6 +50,7 @@ exports[`TimePicker > should render with basic props 1`] = `
         </button>
         <input
           class="flex h-9 rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-gray-900 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 w-full rounded-l-none border-none text-right placeholder:text-right input-field focus:bg-white focus-visible:ring-0 focus-visible:ring-offset-0"
+          id="test-id"
           name="test-time"
           required=""
           value=""

--- a/src/ui/components/data-entry/time-picker/time-picker.tsx
+++ b/src/ui/components/data-entry/time-picker/time-picker.tsx
@@ -2,7 +2,7 @@ import { FormDescription } from '../../../../scalars/components/fragments/form-d
 import { FormGroup } from '../../../../scalars/components/fragments/form-group/form-group.js'
 import { FormLabel } from '../../../../scalars/components/fragments/form-label/form-label.js'
 import { FormMessageList } from '../../../../scalars/components/fragments/form-message/message-list.js'
-import { forwardRef } from 'react'
+import { forwardRef, useId } from 'react'
 import type { InputBaseProps, WithDifference } from '../../../../scalars/components/types.js'
 import type { InputNumberProps } from '../number-input/types.js'
 import type { SelectFieldProps } from '../../../../scalars/components/fragments/select-field/index.js'
@@ -42,7 +42,7 @@ const TimePicker = forwardRef<HTMLInputElement, TimePickerProps>(
   (
     {
       label,
-      id,
+      id: propId,
       errors,
       name,
       placeholder,
@@ -100,6 +100,8 @@ const TimePicker = forwardRef<HTMLInputElement, TimePickerProps>(
       showTimezoneSelect,
       includeContinent,
     })
+    const generatedId = useId()
+    const id = propId ?? generatedId
 
     if (viewMode === 'edition') {
       return (
@@ -110,10 +112,10 @@ const TimePicker = forwardRef<HTMLInputElement, TimePickerProps>(
             </FormLabel>
           )}
           <BasePickerField
+            id={id}
             iconName="Clock"
             isOpen={isOpen}
             name={name}
-            errors={errors}
             disabled={disabled}
             required={required}
             value={inputValue}

--- a/src/ui/components/data-entry/time-picker/use-time-picker.ts
+++ b/src/ui/components/data-entry/time-picker/use-time-picker.ts
@@ -47,6 +47,8 @@ export const useTimePicker = ({
   includeContinent = false,
 }: TimePickerFieldProps) => {
   const [isOpen, setIsOpen] = useState(false)
+  const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod | undefined>(undefined)
+  const [selectedMinute, setSelectedMinute] = useState(getMinutes(value ?? defaultValue ?? ''))
   const is12HourFormat = timeFormat.includes('a') || timeFormat.includes('A')
   const [inputValue, setInputValue] = useState(getInputValue(value ?? defaultValue))
 
@@ -55,10 +57,6 @@ export const useTimePicker = ({
       ? convertTimeFrom24To12Hours(getHours(value ?? defaultValue ?? ''))
       : getHours(value ?? defaultValue ?? '')
   )
-
-  const [selectedMinute, setSelectedMinute] = useState(getMinutes(value ?? defaultValue ?? ''))
-
-  const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod | undefined>(undefined)
 
   const systemTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
   const [selectedTimeZone, setSelectedTimeZone] = useState<string | string[] | undefined>(

--- a/src/ui/components/data-entry/time-picker/use-time-picker.ts
+++ b/src/ui/components/data-entry/time-picker/use-time-picker.ts
@@ -90,7 +90,7 @@ export const useTimePicker = ({
 
     const datetime = formatInputsToValueFormat(hours, minutes, offsetUTC)
     const clearMinutes = cleanTime(minutes)
-    const clearHours = convertTimeFrom24To12Hours(cleanTime(hours))
+    const clearHours = is12HourFormat ? convertTimeFrom24To12Hours(cleanTime(hours)) : cleanTime(hours)
     setSelectedHour(clearHours)
     setSelectedMinute(clearMinutes)
     onChange?.(createChangeEvent(datetime))

--- a/src/ui/components/data-entry/time-picker/utils.test.ts
+++ b/src/ui/components/data-entry/time-picker/utils.test.ts
@@ -150,11 +150,6 @@ describe('transformInputTime', () => {
       expect(result).toEqual({ hour: '09', minute: '30', period: 'AM' })
     })
 
-    // it('should handle input with lowercase AM/PM', () => {
-    //   const result = transformInputTime('09:30 am', true)
-    //   expect(result).toEqual({ hour: '09', minute: '30', period: 'am' })
-    // })
-
     it('should convert 12h if had AM/PM', () => {
       const result = transformInputTime('02:30 PM', false)
       expect(result).toEqual({ hour: '14', minute: '30', period: undefined })

--- a/src/ui/components/data-entry/time-picker/utils.test.ts
+++ b/src/ui/components/data-entry/time-picker/utils.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest'
+import { transformInputTime } from './utils.js'
+
+describe('transformInputTime', () => {
+  describe('empty or null input', () => {
+    it('should return empty values for empty input', () => {
+      const result = transformInputTime('', true)
+      expect(result).toEqual({ hour: '', minute: '', period: undefined })
+    })
+
+    it('should return empty values for input with only spaces', () => {
+      const result = transformInputTime('   ', false)
+      expect(result).toEqual({ hour: '', minute: '', period: undefined })
+    })
+  })
+
+  describe('12-hour format', () => {
+    it('should transform time in 12h format with AM', () => {
+      const result = transformInputTime('09:30 AM', true)
+      expect(result).toEqual({ hour: '09', minute: '30', period: 'AM' })
+    })
+
+    it('should transform time in 12h format with PM', () => {
+      const result = transformInputTime('02:45 PM', true)
+      expect(result).toEqual({ hour: '02', minute: '45', period: 'PM' })
+    })
+
+    it('should automatically convert 24h time to 12h if format is 12h', () => {
+      const result = transformInputTime('14:30', true)
+      expect(result).toEqual({ hour: '02', minute: '30', period: 'PM' })
+    })
+
+    it('should handle noon (12:00) as 12:00 PM', () => {
+      const result = transformInputTime('12:00', true)
+      expect(result).toEqual({ hour: '12', minute: '00', period: 'PM' })
+    })
+
+    it('should determine AM/PM based on original hour when not specified', () => {
+      // Hour 8-11 should be AM
+      const result1 = transformInputTime('09:00', true)
+      expect(result1).toEqual({ hour: '09', minute: '00', period: 'AM' })
+
+      // Hour 1-7 should be PM
+      const result2 = transformInputTime('03:00', true)
+      expect(result2).toEqual({ hour: '03', minute: '00', period: 'PM' })
+    })
+
+    it('should use periodToCheck when provided', () => {
+      const result = transformInputTime('14:30', true, 1, 'AM')
+      expect(result).toEqual({ hour: '02', minute: '30', period: 'AM' })
+    })
+
+    it('should handle input without minutes', () => {
+      const result = transformInputTime('9', true)
+      expect(result).toEqual({ hour: '', minute: '', period: undefined })
+    })
+
+    it('should handle 4-digit input', () => {
+      const result = transformInputTime('1430', true)
+      expect(result).toEqual({ hour: '02', minute: '30', period: 'PM' })
+    })
+  })
+
+  describe('24-hour format', () => {
+    it('should maintain time in 24h format', () => {
+      const result = transformInputTime('14:30', false)
+      expect(result).toEqual({ hour: '14', minute: '30', period: undefined })
+    })
+
+    it('should convert AM/PM to 24h format', () => {
+      const result = transformInputTime('02:30 PM', false)
+      expect(result).toEqual({ hour: '14', minute: '30', period: undefined })
+    })
+
+    it('should convert 12:00 AM to 00:00', () => {
+      const result = transformInputTime('12:00 AM', false)
+      expect(result).toEqual({ hour: '00', minute: '00', period: undefined })
+    })
+
+    it('should maintain 12:00 PM as 12:00', () => {
+      const result = transformInputTime('12:00 PM', false)
+      expect(result).toEqual({ hour: '12', minute: '00', period: undefined })
+    })
+
+    it('should handle input without minutes in 24h format', () => {
+      const result = transformInputTime('14', false)
+      expect(result).toEqual({ hour: '', minute: '', period: undefined })
+    })
+    it('should handle 4-digit input in 24h format', () => {
+      const result = transformInputTime('1430', false)
+      expect(result).toEqual({ hour: '14', minute: '30', period: undefined })
+    })
+  })
+
+  describe('minute rounding', () => {
+    it('should round minutes to specified interval', () => {
+      const result = transformInputTime('09:32', true, 5)
+      expect(result).toEqual({ hour: '09', minute: '30', period: 'AM' })
+    })
+
+    it('should round up when close to next interval', () => {
+      const result = transformInputTime('09:33', true, 5)
+      expect(result).toEqual({ hour: '09', minute: '35', period: 'AM' })
+    })
+
+    it('should round down when close to previous interval', () => {
+      const result = transformInputTime('09:31', true, 5)
+      expect(result).toEqual({ hour: '09', minute: '30', period: 'AM' })
+    })
+
+    it('should handle rounding at 60-minute limit', () => {
+      const result = transformInputTime('09:58', true, 5)
+      expect(result).toEqual({ hour: '09', minute: '55', period: 'AM' })
+    })
+
+    it('should use default interval of 1 minute', () => {
+      const result = transformInputTime('09:30', true)
+      expect(result).toEqual({ hour: '09', minute: '30', period: 'AM' })
+    })
+  })
+
+  describe('edge cases and validation', () => {
+    it('should handle invalid numeric values', () => {
+      const result = transformInputTime('abcd', true)
+      expect(result).toEqual({ hour: '', minute: '', period: undefined })
+    })
+    it('should handle invalid numeric values', () => {
+      const result = transformInputTime('ab:cd', true)
+      console.log('result', result)
+      expect(result).toEqual({ hour: '', minute: '', period: undefined })
+    })
+
+    it('should handle only invalid minutes', () => {
+      const result = transformInputTime('09:ab', true)
+      expect(result).toEqual({ hour: '', minute: '', period: undefined })
+    })
+
+    it('should handle only invalid hours', () => {
+      const result = transformInputTime('ab:30', true)
+      expect(result).toEqual({ hour: '', minute: '', period: undefined })
+    })
+
+    it('should handle input with extra spaces', () => {
+      const result = transformInputTime('  09:30  AM  ', true)
+      expect(result).toEqual({ hour: '09', minute: '30', period: 'AM' })
+    })
+
+    it('should handle input with multiple spaces', () => {
+      const result = transformInputTime('09:30   AM', true)
+      expect(result).toEqual({ hour: '09', minute: '30', period: 'AM' })
+    })
+
+    // it('should handle input with lowercase AM/PM', () => {
+    //   const result = transformInputTime('09:30 am', true)
+    //   expect(result).toEqual({ hour: '09', minute: '30', period: 'am' })
+    // })
+
+    it('should convert 12h if had AM/PM', () => {
+      const result = transformInputTime('02:30 PM', false)
+      expect(result).toEqual({ hour: '14', minute: '30', period: undefined })
+    })
+  })
+
+  describe('complex combinations', () => {
+    it('should handle 24h to 12h conversion with rounding', () => {
+      const result = transformInputTime('14:32', true, 5)
+      expect(result).toEqual({ hour: '02', minute: '30', period: 'PM' })
+    })
+
+    it('should handle 12h to 24h conversion with rounding', () => {
+      const result = transformInputTime('02:32 PM', false, 5)
+      expect(result).toEqual({ hour: '14', minute: '30', period: undefined })
+    })
+
+    it('should handle 4-digit input with rounding', () => {
+      const result = transformInputTime('1432', true, 5)
+      expect(result).toEqual({ hour: '02', minute: '30', period: 'PM' })
+    })
+
+    it('should handle 4-digit input with rounding in 24h format', () => {
+      const result = transformInputTime('1432', false, 5)
+      expect(result).toEqual({ hour: '14', minute: '30', period: undefined })
+    })
+  })
+})

--- a/src/ui/components/data-entry/time-picker/utils.ts
+++ b/src/ui/components/data-entry/time-picker/utils.ts
@@ -36,9 +36,9 @@ export const cleanTime = (time: string) => {
  */
 export const convert24hTo12h = (input: string) => {
   const [hours, minutes] = input.split(':')
-  const hourNum = parseInt(hours, 10)
+  const hourNum = parseInt(hours)
   const period = hourNum >= 12 ? 'PM' : 'AM'
-  const hour12 = hourNum % 12 || 12 // Convierte 0 a 12
+  const hour12 = hourNum % 12 || 12
   return `${hour12}:${minutes} ${period}`
 }
 
@@ -65,7 +65,6 @@ export const roundMinute = (minute: number, interval: number): number => {
   if (remainder >= interval / 2) {
     roundedMinute = minute + (interval - remainder)
     if (roundedMinute >= 60) {
-      // If it exceeds 60, round down
       roundedMinute = minute - remainder
     }
   } else {
@@ -91,7 +90,6 @@ export const transformInputTime = (
 
   input = input.trim()
   if (!input) return { hour: '', minute: '', period: undefined }
-  // If the input is less than 3 characters, return empty values
   if (input.length < 3) return { hour: '', minute: '', period: undefined }
 
   let hourStr = ''
@@ -113,31 +111,26 @@ export const transformInputTime = (
     hourStr = digits.slice(0, 2)
     minuteStr = digits.slice(2, 4)
   }
-  let hourNum = parseInt(hourStr, 10)
-  let minuteNum = parseInt(minuteStr, 10) || 0
+  let hourNum = parseInt(hourStr)
+  let minuteNum = parseInt(minuteStr) || 0
   if (isNaN(hourNum)) hourNum = 0
   if (isNaN(minuteNum)) minuteNum = 0
 
   // Store original hour to determine if input was 24h format
   const originalHour = hourNum
 
-  // Apply the minute rounding using the interval
   minuteNum = roundMinute(minuteNum, interval)
   if (is12HourFormat) {
-    // First convert 24h to 12h format if needed
     if (hourNum > 12) {
       hourNum -= 12
     } else if (hourNum === 0) {
       hourNum = 12
     }
 
-    // If still no period assigned, determine based on original hour
     if (!period) {
       if (originalHour > 12) {
-        // Input was in 24h format and > 12, so it's PM
         period = 'PM'
       } else {
-        // Input was in 12h format, use the 8-11 logic
         period = hourNum >= 8 && hourNum <= 11 ? 'AM' : 'PM'
       }
     }
@@ -173,35 +166,28 @@ export const transformInputTime = (
 export const isValidTimeInput = (input: string): boolean => {
   if (!input) return true
   input = input.trim()
-  // Allow change the format and convert the time
   if (input.includes(':')) {
-    // Split into hours and minutes
     const [hours, minutes] = input.split(':')
     const cleanMinutes = cleanTime(minutes)
     if (isNaN(Number(hours)) || isNaN(Number(cleanMinutes))) {
       return false
     }
-    // Remove the AM/PM from the minutes if exists
 
-    // Hours and minutes must be numbers
-    const hoursNum = parseInt(hours, 10)
-    const minutesNum = parseInt(cleanMinutes, 10)
+    const hoursNum = parseInt(hours)
+    const minutesNum = parseInt(cleanMinutes)
 
     if (isNaN(hoursNum) || isNaN(minutesNum)) {
       return false
     }
 
-    // Hours must be between 0 and 23
     if (hoursNum < 0 || hoursNum > 23) {
       return false
     }
 
-    // Minutes must be between 0 and 59
     if (minutesNum < 0 || minutesNum > 59) {
       return false
     }
 
-    // Minutes must be exactly 2 digits
     if (cleanMinutes.length !== 2) {
       return false
     }
@@ -214,8 +200,8 @@ export const isValidTimeInput = (input: string): boolean => {
     }
     const hourStr = input.length === 3 ? input.slice(0, 1) : input.slice(0, 2)
     const minuteStr = input.slice(-2)
-    const hourNum = parseInt(hourStr, 10)
-    const minuteNum = parseInt(minuteStr, 10)
+    const hourNum = parseInt(hourStr)
+    const minuteNum = parseInt(minuteStr)
     return hourNum >= 0 && hourNum <= 23 && minuteNum >= 0 && minuteNum <= 59
   }
 }
@@ -378,7 +364,7 @@ export const convert12hTo24h = (input: string) => {
   const period = input.includes('AM') || input.includes('PM') ? input.slice(-2) : undefined
   let formattedHours = hours
   if (period === 'PM' && hours !== '12') {
-    formattedHours = (parseInt(hours, 10) + 12).toString()
+    formattedHours = (parseInt(hours) + 12).toString()
   } else if (period === 'AM' && hours === '12') {
     formattedHours = '00'
   }
@@ -456,13 +442,11 @@ export const getHoursAndMinutes = (input: string) => {
         period: undefined,
       }
     }
-    // Return and invalid value as cannot be a value time
     return { hours: '', minutes: '', period: undefined }
   }
 }
 
 export const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-  // Allow control keys (backspace, delete, arrows, etc)
   if (
     e.key === 'Backspace' ||
     e.key === 'Delete' ||
@@ -478,15 +462,12 @@ export const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     return
   }
 
-  // Allow numbers
   if (/^[0-9]$/.test(e.key)) {
     return
   }
-  // Allow ":"
   if (e.key === ':') {
     return
   }
-  // Allow "A", "M", "P" for AM/PM
   if (/^[AMP]$/i.test(e.key)) {
     return
   }


### PR DESCRIPTION
## Ticket
- https://trello.com/c/HnZVa4UX/1063-add-month-year-and-year-only-selection-modes-to-the-datepicker

## Description
- Should support a mode that lets users pick only a month and a year. 