### PR TITLE
fix(scalars): apply default format to value in date-time-picker

### DIFF
--- a/src/scalars/components/date-time-picker-field/__snapshots__/date-time-picker-field.test.tsx.snap
+++ b/src/scalars/components/date-time-picker-field/__snapshots__/date-time-picker-field.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`DateTimePickerField > should match the snapshot 1`] = `
             data-cast="DateTimeString:yyyy-MM-dd"
             name="test-date"
             placeholder="Select date and time"
-            value="2025-01-01 12:00"
+            value="2025-01-01 12:00 PM"
           />
         </div>
       </div>

--- a/src/ui/components/data-entry/date-time-picker/__snapshots__/date-time-picker.test.tsx.snap
+++ b/src/ui/components/data-entry/date-time-picker/__snapshots__/date-time-picker.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`DateTimePicker > should match the snapshot 1`] = `
           data-cast="DateTimeString:yyyy-MM-dd"
           name="test-date"
           placeholder="Select date and time"
-          value="2025-01-01 12:00"
+          value="2025-01-01 12:00 PM"
         />
       </div>
     </div>

--- a/src/ui/components/data-entry/date-time-picker/subcomponent/date-time-picker-diff.tsx
+++ b/src/ui/components/data-entry/date-time-picker/subcomponent/date-time-picker-diff.tsx
@@ -6,8 +6,7 @@ import { cn } from '../../../../../scalars/lib/utils.js'
 import { InputDiff } from '../../input/subcomponent/input-diff.js'
 import { TextDiff } from '../../input/subcomponent/text-diff.js'
 import type { DateFieldValue } from '../../date-picker/types.js'
-import { getDateFormat } from '../utils.js'
-import { parseDateTimeValueToInput } from '../use-date-time-picker.js'
+import { getDateFormat, parseDateTimeValueToInput } from '../utils.js'
 import { formatInputToDisplayValid } from '../../time-picker/utils.js'
 
 interface DateTimeInputDiffProps
@@ -34,11 +33,11 @@ const DateTimeInputDiff = ({
   timeIntervals = 1,
   ...props
 }: DateTimeInputDiffProps) => {
-  const internalFormat = getDateFormat(dateFormat ?? '')
-  const newValue = parseDateTimeValueToInput(value ?? '', internalFormat)
-  const newBaseValue = parseDateTimeValueToInput(baseValue ?? '', internalFormat)
-
   const is12HourFormat = timeFormat.includes('a') || timeFormat.includes('A')
+  const internalFormat = getDateFormat(dateFormat ?? '')
+  const newValue = parseDateTimeValueToInput(value ?? '', internalFormat, is12HourFormat, timeIntervals)
+  const newBaseValue = parseDateTimeValueToInput(baseValue ?? '', internalFormat, is12HourFormat, timeIntervals)
+
   const valueSplitDate = newValue.split(' ')[0]
   const valueSplitTime = newValue.split(' ')[1]
   const formattedValueTime = formatInputToDisplayValid(valueSplitTime, is12HourFormat, timeIntervals)

--- a/src/ui/components/data-entry/date-time-picker/use-date-time-picker.tsx
+++ b/src/ui/components/data-entry/date-time-picker/use-date-time-picker.tsx
@@ -168,14 +168,20 @@ export const useDateTimePicker = ({
     const datetimeFormatted = formatInputToDisplayValid(timeValue, is12HourFormat, timeIntervals, periodInput)
     const validValue = convert12hTo24h(datetimeFormatted)
     const offsetUTC = getOffset(timeZone ?? (selectedTimeZone as string))
-    const { minutes, hours, period } = getHoursAndMinutes(validValue)
+    const { minutes, hours } = getHoursAndMinutes(validValue)
 
     const clearMinutes = cleanTime(minutes)
     const clearHours = convertTimeFrom24To12Hours(cleanTime(hours))
     setSelectedHour(clearHours)
     setSelectedMinute(clearMinutes)
+    const getFormattedTime = datetimeFormatted.split(' ')[1]
+    // Get period from input if exists to avoid use the default period
+    const newPeriod =
+      datetimeFormatted.includes('AM') || datetimeFormatted.includes('PM')
+        ? (datetimeFormatted.split(' ')[1] as TimePeriod)
+        : getFormattedTime
     if (is12HourFormat) {
-      setSelectedPeriod(period as TimePeriod)
+      setSelectedPeriod(newPeriod as TimePeriod)
     }
     const timeFormat = formatInputsToValueFormat(hours, minutes, offsetUTC)
     const newValue = putTimeInValue(value ?? defaultValue ?? '', timeFormat)

--- a/src/ui/components/data-entry/date-time-picker/use-date-time-picker.tsx
+++ b/src/ui/components/data-entry/date-time-picker/use-date-time-picker.tsx
@@ -1,9 +1,8 @@
-import { format } from 'date-fns'
 import React, { useState } from 'react'
 import type { DateFieldValue } from '../date-picker/types.js'
 import { useDatePickerField } from '../date-picker/use-date-picker.js'
-import { getDateFromValue, getTimeFromValue, isFormatDisabled } from '../date-picker/utils.js'
-import type { TimeFieldValue, TimePeriod } from '../time-picker/type.js'
+import { getTimeFromValue, isFormatDisabled } from '../date-picker/utils.js'
+import type { TimePeriod } from '../time-picker/type.js'
 import { convertTimeFrom24To12Hours, useTimePicker } from '../time-picker/use-time-picker.js'
 import {
   cleanTime,
@@ -12,16 +11,19 @@ import {
   formatInputsToValueFormat,
   formatInputToDisplayValid,
   getHoursAndMinutes,
-  getInputValue,
   isValidTimeInput,
 } from '../time-picker/utils.js'
 import {
   createBlurEvent,
+  formatToISODateTimeWithOffset,
   getDateFormat,
   getOffset,
   isDateFormatAllowed,
-  parseInputString,
+  parseDateTimeValueToInput,
+  putDateInValue,
+  putTimeInValue,
   splitDateTimeStringFromInput,
+  todayDateInput,
 } from './utils.js'
 
 interface DateTimeFieldProps {
@@ -52,81 +54,6 @@ interface DateTimeFieldProps {
   includeContinent?: boolean
 }
 
-export const formatToISODateTimeWithOffset = (datePart: string, timePart: string, timeZone?: string): string => {
-  // WIP: think if we need validate timePart before format it with 00 at the end
-  const formattedTime = timePart ? `${timePart}:00` : '00:00:00'
-  // const formattedTime = timePart ? `${timePart}:00` : "00:00:00";
-  const formattedDateTime = `${datePart}T${formattedTime}${getOffset(timeZone)}`
-  // WIP: check the replace sentence
-  const formattedTimeWithMiliseconds = formattedDateTime.replace(/(:\d{2})([+-].*|Z)/, '$1.000$2') || ''
-  return formattedTimeWithMiliseconds
-}
-
-const todayInIsoFormat = () => {
-  return format(new Date(), "yyyy-MM-dd'T'HH:mm:ssXXX")
-}
-
-const todayTimeInput = () => {
-  return format(new Date(), 'HH:mm:ss')
-}
-const todayDateInput = (dateFormat?: string) => {
-  return format(new Date(), dateFormat ?? 'yyyy-MM-dd')
-}
-
-export const parseDateTimeValueToInput = (value: DateFieldValue, dateFormat = 'yyyy-MM-dd') => {
-  const datePart = getDateFromValue(value)
-  const dateFormatted = parseInputString(datePart, dateFormat)
-
-  const timePart = getTimeFromValue(value)
-
-  const timeFormatted = getInputValue(timePart)
-  let date = dateFormatted
-  let time = timeFormatted
-
-  if (!dateFormatted && !timeFormatted) {
-    return ''
-  }
-
-  const dateDefault = todayDateInput()
-  const timeDefault = todayTimeInput()
-
-  if (!dateFormatted) {
-    // set date to today in string format
-    date = dateDefault
-  }
-
-  if (!timeFormatted) {
-    // set time to current time in string format
-    time = timeDefault
-  }
-  return `${date} ${time}`
-}
-
-const putTimeInValue = (value: DateFieldValue, time: TimeFieldValue) => {
-  let datePart = getDateFromValue(value)
-  // put today if datePart is empty
-  if (!datePart) {
-    const today = todayInIsoFormat()
-    datePart = getDateFromValue(today)
-  }
-  return `${datePart}T${time}`
-}
-
-const putDateInValue = (value: DateFieldValue, date: DateFieldValue) => {
-  let timePart = getTimeFromValue(value)
-
-  // if dont have timePart add default time today
-  if (!timePart) {
-    const today = todayInIsoFormat()
-    timePart = getTimeFromValue(today)
-  }
-
-  const datePart = getDateFromValue(date)
-  const newValue = `${datePart}T${timePart}`
-  const formattedTime = newValue.replace(/(:\d{2})([+-].*|Z)/, '$1.000$2') || ''
-  return formattedTime
-}
-
 export const useDateTimePicker = ({
   value,
   defaultValue,
@@ -143,31 +70,32 @@ export const useDateTimePicker = ({
   maxDate,
 
   // Time Picker Field
-  timeFormat,
-  timeIntervals,
+  timeFormat = 'h:mm a',
+  timeIntervals = 1,
   timeZone,
   showTimezoneSelect = true,
   includeContinent,
 }: DateTimeFieldProps) => {
   const internalFormat = getDateFormat(dateFormat ?? '')
+  const is12HourFormat = timeFormat.includes('a') || timeFormat.includes('A')
   const [isOpen, setIsOpen] = React.useState(false)
   const [activeTab, setActiveTab] = useState<'date' | 'time'>('date')
 
   const [dateTimeToDisplay, setDateTimeToDisplay] = useState(
-    parseDateTimeValueToInput(value ?? defaultValue ?? '', internalFormat ?? '')
+    parseDateTimeValueToInput(value ?? defaultValue ?? '', internalFormat ?? '', is12HourFormat, timeIntervals)
   )
 
   const onChangeDate = (e: React.ChangeEvent<HTMLInputElement>) => {
     // TODO: parse date and time to correct format
     const date = e.target.value
     const newValue = putDateInValue(value ?? defaultValue ?? '', date)
-    const newVInput = parseDateTimeValueToInput(newValue, internalFormat)
+    const newVInput = parseDateTimeValueToInput(newValue, internalFormat, is12HourFormat, timeIntervals)
 
     const splitTime = newVInput.split(' ')[1]
     const splitDate = newVInput.split(' ')[0]
+    const periodCheck = Number(newValue.split('T')[1].split(':')[0]) > 12 ? 'PM' : 'AM'
 
-    const transformedTime = formatInputToDisplayValid(splitTime, is12HourFormat, timeIntervals)
-
+    const transformedTime = formatInputToDisplayValid(splitTime, is12HourFormat, timeIntervals, periodCheck)
     const { hours, minutes, period } = getHoursAndMinutes(transformedTime)
 
     setSelectedHour(cleanTime(hours))
@@ -176,7 +104,6 @@ export const useDateTimePicker = ({
       setSelectedPeriod(period as TimePeriod)
     }
     const inputDisplay = `${splitDate.toLocaleUpperCase()} ${transformedTime}`
-
     setDateTimeToDisplay(inputDisplay)
     onChange?.(createChangeEvent(newValue))
     // Add onBlur event to update the value when select a date from calendar
@@ -204,7 +131,7 @@ export const useDateTimePicker = ({
     const time = e.target.value
 
     const newValue = putTimeInValue(value ?? defaultValue ?? '', time)
-    const newVInput = parseDateTimeValueToInput(newValue, internalFormat)
+    const newVInput = parseDateTimeValueToInput(newValue, internalFormat, is12HourFormat, timeIntervals)
     setDateTimeToDisplay(newVInput)
     onChange?.(createChangeEvent(newValue))
   }
@@ -280,7 +207,6 @@ export const useDateTimePicker = ({
     minutes,
     timeZonesOptions,
     selectedTimeZone,
-    is12HourFormat,
     setSelectedTimeZone,
     isDisableSelect,
   } = useTimePicker({
@@ -333,23 +259,6 @@ export const useDateTimePicker = ({
   const handleOnSave = () => {
     setIsOpen(false)
     const offsetUTC = timeZone ? getOffset(timeZone) : getOffset(selectedTimeZone as string)
-
-    setSelectedHour(cleanTime(selectedHour))
-    setSelectedMinute(cleanTime(selectedMinute))
-
-    const newValueTime = formatInputsToValueFormat(selectedHour, selectedMinute, offsetUTC)
-
-    // If there are no hours and minutes selected, do nothing
-    if (!selectedHour && !selectedMinute) {
-      return
-    }
-    // Set default values
-    let hourToUse = selectedHour
-    if (!selectedHour && selectedMinute) {
-      hourToUse = is12HourFormat ? '12' : '00'
-      setSelectedHour(hourToUse)
-    }
-
     let periodToUse = selectedPeriod
     if (is12HourFormat && !selectedPeriod) {
       const hourNum = selectedHour && selectedHour !== '' ? parseInt(selectedHour) : 0
@@ -360,12 +269,30 @@ export const useDateTimePicker = ({
       setSelectedPeriod(periodToUse)
     }
 
+    setSelectedHour(cleanTime(selectedHour))
+    setSelectedMinute(cleanTime(selectedMinute))
+    const datetimeFormatted = is12HourFormat
+      ? `${selectedHour}:${selectedMinute} ${periodToUse}`
+      : `${selectedHour}:${selectedMinute}`
+    const convertedTime = convert12hTo24h(datetimeFormatted)
+    const [hours, minutes] = convertedTime.split(':')
+    const newValueTime = formatInputsToValueFormat(hours, minutes, offsetUTC)
+    // If there are no hours and minutes selected, do nothing
+    if (!selectedHour && !selectedMinute) {
+      return
+    }
+    // Set default values
+    let hourToUse = selectedHour
+    if (!selectedHour && selectedMinute) {
+      hourToUse = is12HourFormat ? '12' : '00'
+      setSelectedHour(hourToUse)
+    }
     const timeToDisplay = is12HourFormat
       ? `${hourToUse}:${selectedMinute} ${periodToUse}`
       : `${hourToUse}:${selectedMinute}`
 
     const newValue = putTimeInValue(value ?? defaultValue ?? '', newValueTime)
-    let valueDate = parseDateTimeValueToInput(newValue, internalFormat).split(' ')[0]
+    let valueDate = parseDateTimeValueToInput(newValue, internalFormat, is12HourFormat, timeIntervals).split(' ')[0]
     // Check if the date is valid if not add today date to the value
     const isValid = isDateFormatAllowed(valueDate, internalFormat)
     if (!isValid) {

--- a/src/ui/components/data-entry/date-time-picker/utils.test.ts
+++ b/src/ui/components/data-entry/date-time-picker/utils.test.ts
@@ -1,0 +1,46 @@
+import { roundMinute } from '../time-picker/utils'
+import { parseDateTimeValueToInput } from './utils'
+
+describe('parseDateTimeValueToInput', () => {
+  it('should return an empty string if no date or time value is provided', () => {
+    const result = parseDateTimeValueToInput('', '', false, 1)
+    expect(result).toBe('')
+  })
+
+  it('should correctly format the date and time in 24-hour format', () => {
+    const result = parseDateTimeValueToInput('2024-03-10T14:45', 'yyyy-MM-dd', false, 1)
+    expect(result).toBe('2024-03-10 14:45')
+  })
+
+  it('should correctly format the date and time in 12-hour format (AM - 09:00)', () => {
+    const result = parseDateTimeValueToInput('2024-03-10T09:00', 'yyyy-MM-dd', true, 15)
+    expect(result).toBe('2024-03-10 09:00 AM')
+  })
+
+  it('should correctly format the date and time in 12-hour format (PM - 17:30)', () => {
+    const result = parseDateTimeValueToInput('2024-03-10T17:30', 'yyyy-MM-dd', true, 10)
+    expect(result).toBe('2024-03-10 05:30 PM')
+  })
+
+  it('should handle minute rounding based on timeIntervals', () => {
+    const result = parseDateTimeValueToInput('2024-01-01T10:07', 'yyyy-MM-dd', false, 5)
+    expect(result).toBe('2024-01-01 10:05')
+    expect(roundMinute(7, 5)).toBe(5)
+  })
+
+  it('should format 00:XX as 00:XX PM in 12-hour format (current logic)', () => {
+    const result = parseDateTimeValueToInput('2024-03-10T00:05', 'yyyy-MM-dd', true, 1)
+    expect(result).toBe('2024-03-10 00:05 PM')
+  })
+
+  it('should format 12:XX as 12:XX PM in 12-hour format', () => {
+    const result = parseDateTimeValueToInput('2024-03-10T12:00', 'yyyy-MM-dd', true, 1)
+    expect(result).toBe('2024-03-10 12:00 PM')
+  })
+
+  it('should format 23:XX as 11:XX PM in 12-hour format', () => {
+    const result = parseDateTimeValueToInput('2024-03-10T23:59', 'yyyy-MM-dd', true, 1)
+
+    expect(result).toBe('2024-03-10 11:59 PM')
+  })
+})

--- a/src/ui/components/data-entry/date-time-picker/utils.ts
+++ b/src/ui/components/data-entry/date-time-picker/utils.ts
@@ -274,11 +274,8 @@ export const getCalendarType = (dateFormat: string): 'years' | 'months' | 'days'
 }
 
 export const formatToISODateTimeWithOffset = (datePart: string, timePart: string, timeZone?: string): string => {
-  // WIP: think if we need validate timePart before format it with 00 at the end
   const formattedTime = timePart ? `${timePart}:00` : '00:00:00'
-  // const formattedTime = timePart ? `${timePart}:00` : "00:00:00";
   const formattedDateTime = `${datePart}T${formattedTime}${getOffset(timeZone)}`
-  // WIP: check the replace sentence
   const formattedTimeWithMiliseconds = formattedDateTime.replace(/(:\d{2})([+-].*|Z)/, '$1.000$2') || ''
   return formattedTimeWithMiliseconds
 }
@@ -317,12 +314,10 @@ export const parseDateTimeValueToInput = (
   const timeDefault = todayTimeInput()
 
   if (!dateFormatted) {
-    // set date to today in string format
     date = dateDefault
   }
 
   if (!timeFormatted) {
-    // set time to current time in string format
     time = timeDefault
   }
   const hours = Number(time.split(':')[0])
@@ -331,7 +326,6 @@ export const parseDateTimeValueToInput = (
   const period = is12HourFormat ? (hours >= 8 && hours <= 11 ? 'AM' : 'PM') : undefined
   const hoursToShow12HoursFormat = String(hours > 12 ? hours - 12 : hours).padStart(2, '0')
   const hoursToShow24HoursFormat = String(hours).padStart(2, '0')
-  // const hours12Hours = Number(time.split(':')[0]) - 12
   const formattedDateTime = is12HourFormat
     ? `${date} ${hoursToShow12HoursFormat}:${minutesWithInterval} ${period}`
     : `${date} ${hoursToShow24HoursFormat}:${minutesWithInterval}`
@@ -341,7 +335,6 @@ export const parseDateTimeValueToInput = (
 
 export const putTimeInValue = (value: DateFieldValue, time: TimeFieldValue) => {
   let datePart = getDateFromValue(value)
-  // put today if datePart is empty
   if (!datePart) {
     const today = todayInIsoFormat()
     datePart = getDateFromValue(today)
@@ -352,7 +345,6 @@ export const putTimeInValue = (value: DateFieldValue, time: TimeFieldValue) => {
 export const putDateInValue = (value: DateFieldValue, date: DateFieldValue) => {
   let timePart = getTimeFromValue(value)
 
-  // if dont have timePart add default time today
   if (!timePart) {
     const today = todayInIsoFormat()
     timePart = getTimeFromValue(today)

--- a/src/ui/components/data-entry/time-picker/time-picker.test.tsx
+++ b/src/ui/components/data-entry/time-picker/time-picker.test.tsx
@@ -323,7 +323,7 @@ describe('TimePicker', () => {
       render(<TimePicker name="test-time" label="Test Label" viewMode="edition" value="14:30" />)
       const input = screen.getByRole('textbox')
       expect(input).toBeInTheDocument()
-      expect(input).toHaveValue('14:30')
+      expect(input).toHaveValue('02:30 PM')
     })
   })
 })

--- a/src/ui/components/data-entry/time-picker/use-time-picker.ts
+++ b/src/ui/components/data-entry/time-picker/use-time-picker.ts
@@ -13,6 +13,7 @@ import {
   getMinutes,
   getOffsetToDisplay,
   getOptions,
+  getPeriodFromTime,
   getTimezone,
   INVALID_TIME_INPUT,
   isValidTimeInput,
@@ -48,11 +49,15 @@ export const useTimePicker = ({
   includeContinent = false,
 }: TimePickerFieldProps) => {
   const [isOpen, setIsOpen] = useState(false)
-  const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod | undefined>(undefined)
-  const [selectedMinute, setSelectedMinute] = useState(getMinutes(value ?? defaultValue ?? ''))
   const is12HourFormat = timeFormat.includes('a') || timeFormat.includes('A')
-  const [inputValue, setInputValue] = useState(getInputValue(value ?? defaultValue))
+  const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod | undefined>(
+    getPeriodFromTime(value ?? defaultValue ?? '', is12HourFormat)
+  )
+  const [selectedMinute, setSelectedMinute] = useState(getMinutes(value ?? defaultValue ?? ''))
 
+  const [inputValue, setInputValue] = useState(
+    formatInputToDisplayValid(getInputValue(value ?? defaultValue), is12HourFormat, timeIntervals, selectedPeriod)
+  )
   const [selectedHour, setSelectedHour] = useState(
     is12HourFormat
       ? convertTimeFrom24To12Hours(getHours(value ?? defaultValue ?? ''))
@@ -66,9 +71,20 @@ export const useTimePicker = ({
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const input = e.target.value
+    if (!isValidTimeInput(input)) {
+      onChange?.(createChangeEvent(INVALID_TIME_INPUT))
+    }
     setInputValue(input)
-  }
+    const offsetUTC = getOffset(selectedTimeZone as string)
+    const { minutes, hours } = getHoursAndMinutes(input)
+    const datetime = formatInputsToValueFormat(hours, minutes, offsetUTC)
+    const period = getPeriodFromTime(datetime, is12HourFormat)
 
+    setSelectedPeriod(period)
+
+    onChange?.(createChangeEvent(datetime))
+    onBlur?.(createBlurEvent(datetime))
+  }
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const input = e.target.value
     if (!isValidTimeInput(input)) {
@@ -86,13 +102,9 @@ export const useTimePicker = ({
 
     const validValue = convert12hTo24h(valueForInput)
 
-    const { minutes, hours, period } = getHoursAndMinutes(validValue)
+    const { minutes, hours } = getHoursAndMinutes(validValue)
 
     const offsetUTC = getOffset(selectedTimeZone as string)
-
-    if (is12HourFormat) {
-      setSelectedPeriod(period as TimePeriod)
-    }
 
     const datetime = formatInputsToValueFormat(hours, minutes, offsetUTC)
     const clearMinutes = cleanTime(minutes)

--- a/src/ui/components/data-entry/time-picker/use-time-picker.ts
+++ b/src/ui/components/data-entry/time-picker/use-time-picker.ts
@@ -71,19 +71,17 @@ export const useTimePicker = ({
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const input = e.target.value
-    if (!isValidTimeInput(input)) {
-      onChange?.(createChangeEvent(INVALID_TIME_INPUT))
-    }
     setInputValue(input)
     const offsetUTC = getOffset(selectedTimeZone as string)
     const { minutes, hours } = getHoursAndMinutes(input)
     const datetime = formatInputsToValueFormat(hours, minutes, offsetUTC)
-    const period = getPeriodFromTime(datetime, is12HourFormat)
+    const newDatetime = datetime === '' ? INVALID_TIME_INPUT : datetime
+    const period = getPeriodFromTime(newDatetime, is12HourFormat)
+    // Get period from input if exists to avoid use the default period
+    const newPeriod = input.includes('AM') || input.includes('PM') ? (input.split(' ')[1] as TimePeriod) : period
 
-    setSelectedPeriod(period)
-
-    onChange?.(createChangeEvent(datetime))
-    onBlur?.(createBlurEvent(datetime))
+    setSelectedPeriod(newPeriod)
+    onChange?.(createChangeEvent(newDatetime))
   }
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const input = e.target.value

--- a/src/ui/components/data-entry/time-picker/utils.ts
+++ b/src/ui/components/data-entry/time-picker/utils.ts
@@ -505,3 +505,11 @@ export const getHoursAndMinutesFromValue = (timeString: string) => {
 }
 
 export const INVALID_TIME_INPUT = '9999:99999'
+
+export const getPeriodFromTime = (time: string, is12HourFormat: boolean) => {
+  if (!time) return undefined
+  if (!is12HourFormat) return undefined
+
+  const hours = Number(time.split(':')[0])
+  return hours >= 8 && hours <= 11 ? 'AM' : 'PM'
+}

--- a/src/ui/components/data-entry/time-picker/utils.ts
+++ b/src/ui/components/data-entry/time-picker/utils.ts
@@ -509,7 +509,10 @@ export const INVALID_TIME_INPUT = '9999:99999'
 export const getPeriodFromTime = (time: string, is12HourFormat: boolean) => {
   if (!time) return undefined
   if (!is12HourFormat) return undefined
-
+  // Add condition if inclued period
+  if (time.includes('AM') || time.includes('PM')) {
+    return time.split(' ')[1] as TimePeriod
+  }
   const hours = Number(time.split(':')[0])
   return hours >= 8 && hours <= 11 ? 'AM' : 'PM'
 }

--- a/src/ui/components/data-entry/time-picker/utils.ts
+++ b/src/ui/components/data-entry/time-picker/utils.ts
@@ -509,7 +509,6 @@ export const INVALID_TIME_INPUT = '9999:99999'
 export const getPeriodFromTime = (time: string, is12HourFormat: boolean) => {
   if (!time) return undefined
   if (!is12HourFormat) return undefined
-  // Add condition if inclued period
   if (time.includes('AM') || time.includes('PM')) {
     return time.split(' ')[1] as TimePeriod
   }


### PR DESCRIPTION
## Ticket
- https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

## Description
- The error "Invalid date format. Use undefined" appears when the time and date values are swapped — e.g., 12:20 2025-06-22 instead of the expected 2025-06-22 12:20.

- When a date is set via the defaultValue parameter for the DateTimePicker field, the time is displayed with seconds (HH:mm:ss) on page load or refresh, which does not match the expected HH:mm format and fails validation.