### PR TITLE
feat: add support for custom editor renderers

### DIFF
--- a/src/scalars/components/form/form.tsx
+++ b/src/scalars/components/form/form.tsx
@@ -137,6 +137,7 @@ const Form = forwardRef<UseFormReturn, FormProps>(
       submissionErrorMatcher = defaultOnError,
       className,
       extraFormProps,
+      ...props
     },
     ref
   ) => {
@@ -237,7 +238,7 @@ const Form = forwardRef<UseFormReturn, FormProps>(
 
         {/* This is how react-hook-form works, it expects a promise to be returned from the onSubmit callback */}
         {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
-        <form id={formId} onSubmit={methods.handleSubmit(wrappedOnSubmit)} className={className} noValidate>
+        <form id={formId} onSubmit={methods.handleSubmit(wrappedOnSubmit)} className={className} noValidate {...props}>
           {typeof children === 'function'
             ? children({
                 ...methods,

--- a/src/scalars/components/fragments/with-field-validation/with-field-validation.tsx
+++ b/src/scalars/components/fragments/with-field-validation/with-field-validation.tsx
@@ -88,7 +88,6 @@ export const withFieldValidation = <T extends PossibleProps, R extends React.Ele
           render={({
             field: {
               // just preventing that onChange is included in the rest of the props
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
               onChange: _,
               onBlur: onBlurController,
               value: internalValue,

--- a/src/ui/components/data-entry/time-picker/utils.test.ts
+++ b/src/ui/components/data-entry/time-picker/utils.test.ts
@@ -126,7 +126,6 @@ describe('transformInputTime', () => {
     })
     it('should handle invalid numeric values', () => {
       const result = transformInputTime('ab:cd', true)
-      console.log('result', result)
       expect(result).toEqual({ hour: '', minute: '', period: undefined })
     })
 

--- a/src/ui/components/object-set-table/hooks/useGlobalTableKeyEvents.tsx
+++ b/src/ui/components/object-set-table/hooks/useGlobalTableKeyEvents.tsx
@@ -12,13 +12,16 @@ const useGlobalTableKeyEvents = () => {
 
       if (isEditing) {
         if (e.key === 'Enter') {
-          api.exitCellEditMode(true)
+          // TODO: uncomment this once the exit cell mode is enabled
+          // api.exitCellEditMode(true)
         }
         if (e.key === 'Escape' && !!selectedCell) {
           api.exitCellEditMode(false)
         }
       } else {
         if (e.key === 'Enter' && !!selectedCell && api.canEditCell(selectedCell.row, selectedCell.column)) {
+          // prevent the form from being submitted when the cell enters in edit mode
+          e.preventDefault()
           api.enterCellEditMode(selectedCell.row, selectedCell.column)
         }
 

--- a/src/ui/components/object-set-table/logic/table-api.ts
+++ b/src/ui/components/object-set-table/logic/table-api.ts
@@ -135,15 +135,8 @@ class TableApi<TData> implements PrivateTableApiBase<TData> {
     this.selection.selectCell(selectedCell.row, selectedCell.column)
 
     if (save) {
-      const value = this._getConfig().columns[selectedCell.column]?.valueGetter?.(
-        this._getState().data[selectedCell.row],
-        this._createCellContext(selectedCell.row, selectedCell.column)
-      )
-      this._getConfig().columns[selectedCell.column]?.onSave?.(
-        `${value?.toString() ?? ''} edited`,
-        this._createCellContext(selectedCell.row, selectedCell.column)
-      )
-
+      // the actual save is done in the form onSubmit callback
+      // so we just asume that the save was done and we can move to the next cell
       const nextCell = getNextSelectedCell({
         direction: 'down',
         currentCell: selectedCell,

--- a/src/ui/components/object-set-table/object-set-table.stories.tsx
+++ b/src/ui/components/object-set-table/object-set-table.stories.tsx
@@ -505,9 +505,9 @@ export const ReadOnly: Story = {
 export const CellTypes: Story = {
   args: {
     columns: [
-      { field: 'firstName', type: 'text', title: 'Text Field' },
-      { field: 'payment', type: 'number', title: 'Number Field' },
-      { field: 'isActive', type: 'boolean', title: 'Boolean Field' },
+      { field: 'firstName', type: 'text', title: 'Text Field', editable: true },
+      { field: 'payment', type: 'number', title: 'Number Field', editable: true },
+      { field: 'isActive', type: 'boolean', title: 'Boolean Field', editable: true },
     ],
     data: mockData.slice(0, 5),
   },

--- a/src/ui/components/object-set-table/object-set-table.tsx
+++ b/src/ui/components/object-set-table/object-set-table.tsx
@@ -10,6 +10,7 @@ import type { ColumnType, DataType, ObjectSetTableConfig } from './types.js'
 import { defaultColumnAlignment } from './subcomponents/default-fns/default-column-config.js'
 import { defaultHeaderRenderer } from './subcomponents/default-header-renderers/default-header-renderer.js'
 import { defaultSortFns } from './subcomponents/default-sort-columns/default-sort-fns.js'
+import { getCellEditorFn } from './subcomponents/default-cell-editors/get-cell-editor-fn.js'
 
 /**
  * The ObjectSetTable component is a table component that displays a list of objects.
@@ -43,6 +44,7 @@ const ObjectSetTable = <T extends DataType = DataType>(config: ObjectSetTableCon
             config.data[context.rowIndex][context.column.field as keyof T] = value as T[keyof T]
             return true
           }),
+        renderCellEditor: column.renderCellEditor ?? getCellEditorFn(column.type),
         // sorting
         sortable: column.sortable ?? false,
         defaultSortDirection: column.defaultSortDirection ?? 'asc',

--- a/src/ui/components/object-set-table/subcomponents/cells/render-cell.tsx
+++ b/src/ui/components/object-set-table/subcomponents/cells/render-cell.tsx
@@ -1,9 +1,9 @@
 import { useCallback } from 'react'
-import { Input } from '../../../data-entry/input/index.js'
 import type { CellContext, ColumnDef, DataType } from '../../types.js'
 import { isCellEqual } from '../../utils.js'
 import { useInternalTableState } from '../table-provider/table-provider.js'
 import { DefaultTableCell } from './default-cell.js'
+import { Form } from '../../../../../scalars/components/form/form.js'
 
 interface RenderCellProps<T extends DataType> {
   rowItem: T
@@ -87,6 +87,8 @@ const RenderCell = <T extends DataType>({
 
   const isThisCellEditMode = isCellEditMode && isThisCellSelected
 
+  const formRef = api._getState().dataFormReferences[rowIndex][columnIndex]
+
   return (
     <DefaultTableCell
       key={column.field}
@@ -95,17 +97,17 @@ const RenderCell = <T extends DataType>({
       isEditable={column.editable ?? false}
     >
       {isThisCellEditMode ? (
-        <Input
-          className="max-w-full"
-          autoFocus
-          defaultValue={column.valueGetter?.(rowItem, cellContext) as string}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              const newValue = (e.target as HTMLInputElement).value
-              column.onSave?.(newValue, cellContext)
-            }
+        <Form
+          ref={formRef}
+          onSubmit={(data: Record<string, unknown>) => {
+            const value = data[column.field]
+            column.onSave?.(value, cellContext)
+            api.exitCellEditMode()
           }}
-        />
+          submitChangesOnly
+        >
+          {column.renderCellEditor?.(cellValue, () => null, cellContext)}
+        </Form>
       ) : (
         column.renderCell?.(cellValue, cellContext)
       )}

--- a/src/ui/components/object-set-table/subcomponents/default-cell-editors/boolean-editor.tsx
+++ b/src/ui/components/object-set-table/subcomponents/default-cell-editors/boolean-editor.tsx
@@ -1,0 +1,20 @@
+import { Checkbox } from '../../../data-entry/checkbox/checkbox.js'
+import type { CellContext, RenderCellEditorFn } from '../../types.js'
+
+export const booleanCellEditor: RenderCellEditorFn<any, unknown> = (
+  value: unknown,
+  onChange: (newValue: unknown) => void,
+  _context?: CellContext<any>
+) => {
+  const booleanValue = Boolean(value)
+
+  return (
+    <Checkbox
+      autoFocus
+      defaultValue={booleanValue}
+      onChange={(checked: boolean) => {
+        onChange(checked)
+      }}
+    />
+  )
+}

--- a/src/ui/components/object-set-table/subcomponents/default-cell-editors/get-cell-editor-fn.ts
+++ b/src/ui/components/object-set-table/subcomponents/default-cell-editors/get-cell-editor-fn.ts
@@ -1,0 +1,19 @@
+import type { ColumnType, RenderCellEditorFn } from '../../types.js'
+import { booleanCellEditor } from './boolean-editor.js'
+import { numberCellEditor } from './number-editor.js'
+import { textCellEditor } from './text-editor.js'
+
+export const getCellEditorFn = <T>(type?: ColumnType): RenderCellEditorFn<T, unknown> => {
+  switch (type) {
+    case 'text':
+      return textCellEditor
+    case 'number':
+      return numberCellEditor
+    case 'boolean':
+      return booleanCellEditor
+    case undefined:
+      return textCellEditor
+    default:
+      return textCellEditor
+  }
+}

--- a/src/ui/components/object-set-table/subcomponents/default-cell-editors/number-editor.tsx
+++ b/src/ui/components/object-set-table/subcomponents/default-cell-editors/number-editor.tsx
@@ -1,0 +1,22 @@
+import { NumberInput } from '../../../data-entry/number-input/number-input.js'
+import type { CellContext, RenderCellEditorFn } from '../../types.js'
+
+export const numberCellEditor: RenderCellEditorFn<any, unknown> = (
+  value: unknown,
+  onChange: (newValue: unknown) => unknown,
+  _context?: CellContext<any>
+) => {
+  const numericValue = typeof value === 'number' ? value : Number(value) || 0
+
+  return (
+    <NumberInput
+      name="cell-editor"
+      className="max-w-full"
+      autoFocus
+      defaultValue={numericValue}
+      onChange={(newValue) => {
+        onChange(newValue)
+      }}
+    />
+  )
+}

--- a/src/ui/components/object-set-table/subcomponents/default-cell-editors/text-editor.tsx
+++ b/src/ui/components/object-set-table/subcomponents/default-cell-editors/text-editor.tsx
@@ -1,0 +1,21 @@
+import { StringField } from '../../../../../scalars/components/string-field/string-field.js'
+import type { CellContext, RenderCellEditorFn } from '../../types.js'
+
+export const textCellEditor: RenderCellEditorFn<any, unknown> = (
+  value: unknown,
+  onChange: (newValue: unknown) => void,
+  context: CellContext<unknown>
+) => {
+  const stringValue = typeof value === 'string' ? value : String(value ?? '')
+  return (
+    <StringField
+      name={context.column.field}
+      className="max-w-full"
+      autoFocus
+      value={stringValue}
+      onChange={(e) => {
+        onChange(e.target.value)
+      }}
+    />
+  )
+}

--- a/src/ui/components/object-set-table/subcomponents/table-provider/table-provider.tsx
+++ b/src/ui/components/object-set-table/subcomponents/table-provider/table-provider.tsx
@@ -4,6 +4,7 @@ import { tableReducer, type TableState } from './table-reducer.js'
 import { createPublicTableApi } from '../../logic/public-table-api.js'
 import type { PrivateTableApiBase, TableApiBase } from '../../logic/types.js'
 import { TableApi } from '../../logic/table-api.js'
+import { createFormReferences } from '../../utils.js'
 
 interface TableContextValue<T extends DataType = DataType> {
   config: ObjectSetTableConfig<T>
@@ -30,6 +31,7 @@ const TableProvider = <T extends DataType>({ children, config, tableRef }: Table
   const [state, dispatch] = useReducer(tableReducer<T>, {
     columns: config.columns,
     defaultData: [...config.data],
+    dataFormReferences: createFormReferences(config.data.length, config.columns),
     data: config.data,
     allowRowSelection: config.allowRowSelection ?? true,
     showRowNumbers: config.showRowNumbers ?? true,

--- a/src/ui/components/object-set-table/subcomponents/table-provider/table-reducer.tsx
+++ b/src/ui/components/object-set-table/subcomponents/table-provider/table-reducer.tsx
@@ -1,4 +1,6 @@
 import type { ColumnDef, DataType, ObjectSetTableConfig, SortDirection, TableCellIndex } from '../../types.js'
+import type { UseFormReturn } from 'react-hook-form'
+import { createFormReferences } from '../../utils.js'
 
 interface TableState<T extends DataType = DataType> {
   dispatch?: React.Dispatch<TableAction<T>>
@@ -7,6 +9,7 @@ interface TableState<T extends DataType = DataType> {
 
   columns: ColumnDef[]
   data: T[]
+  dataFormReferences: Array<Array<React.RefObject<UseFormReturn> | null>>
   allowRowSelection: boolean
   showRowNumbers: boolean
   selectedRowIndexes: number[]
@@ -95,11 +98,13 @@ const tableReducer = <T extends DataType>(state: TableState<T>, action: TableAct
       return {
         ...state,
         columns: action.payload,
+        dataFormReferences: createFormReferences(state.data.length, action.payload),
       }
     case 'SET_DATA':
       return {
         ...state,
         data: action.payload,
+        dataFormReferences: createFormReferences(action.payload.length, state.columns),
       }
     case 'UPDATE_COLUMN':
       return {

--- a/src/ui/components/object-set-table/types.ts
+++ b/src/ui/components/object-set-table/types.ts
@@ -176,6 +176,12 @@ export type RenderHeaderFn<T, V = string> = (value: V, context: CellContext<T>) 
  */
 export type OnCellSaveFn<TData, TCellValue> = (newValue: TCellValue, context: CellContext<TData>) => boolean
 
+export type RenderCellEditorFn<TData, TCellValue> = (
+  value: TCellValue,
+  onChange: (newValue: TCellValue) => void,
+  context: CellContext<TData>
+) => React.ReactNode
+
 export type SortDirection = 'asc' | 'desc'
 
 export interface SortableColumnDef<T = unknown> {
@@ -348,6 +354,23 @@ export interface ColumnDef<T = any> extends SortableColumnDef<T> {
    * @returns Whether the value was saved.
    */
   onSave?: OnCellSaveFn<T, unknown>
+
+  /**
+   * A function that renders the cell editor. The editor requires to be a controlled component
+   * to save and validate the value properly using the `value` and `onChange` parameters.
+   *
+   * @param value The value to display in the cell editor.
+   * @param onChange The function to call when the value changes.
+   * @param context The cell context.
+   *
+   * @example
+   * ```ts
+   * const renderCellEditor = (value: unknown, onChange: (newValue: unknown) => unknown, context: CellContext<T>) => {
+   *   return <Input value={value} onChange={(e) => onChange(e.target.value)} />
+   * }
+   * ```
+   */
+  renderCellEditor?: RenderCellEditorFn<T, unknown>
 
   /**
    * The width of the column. It accepts any valid CSS width value.

--- a/src/ui/components/object-set-table/utils.ts
+++ b/src/ui/components/object-set-table/utils.ts
@@ -1,4 +1,6 @@
+import type { UseFormReturn } from 'react-hook-form'
 import type { ColumnDef, DataType, TableCellIndex } from './types.js'
+import { createRef } from 'react'
 
 /**
  * Get the title of a column.
@@ -197,4 +199,32 @@ export const isCellEqual = (cell1: TableCellIndex | null, cell2: TableCellIndex 
     return false
   }
   return cell1.row === cell2.row && cell1.column === cell2.column
+}
+
+/**
+ * Create form references for the for of the editable cells in the table.
+ *
+ * @param rowCount - The number of rows in the table.
+ * @param columnDefs - The column definitions.
+ * @returns The form references.
+ */
+export const createFormReferences = (
+  rowCount: number,
+  columnDefs: ColumnDef[]
+): Array<Array<React.RefObject<UseFormReturn> | null>> => {
+  if (rowCount === 0 || columnDefs.length === 0) {
+    return []
+  }
+
+  const formReferences: Array<Array<React.RefObject<UseFormReturn> | null>> = []
+
+  for (let row = 0; row < rowCount; row++) {
+    const refs: Array<React.RefObject<UseFormReturn> | null> = []
+    columnDefs.forEach((columnDef) => {
+      refs.push(columnDef.editable ? createRef<UseFormReturn>() : null)
+    })
+    formReferences.push(refs)
+  }
+
+  return formReferences
 }


### PR DESCRIPTION
## Ticket
https://trello.com/c/0aKPljMD/936-apply-edition-mode-to-the-table

## Description
- Add the ability to add custom cell editors for editable columns
- Added default editors for string (text), number, and boolean
