### PR TITLE
fix(scalars): add validations for invalid values

### DIFF
--- a/src/scalars/components/date-time-picker-field/date-time-picker-field-validations.ts
+++ b/src/scalars/components/date-time-picker-field/date-time-picker-field-validations.ts
@@ -23,11 +23,16 @@ export const dateTimeFieldValidations =
     timeIntervals,
   }: DateTimePickerFieldProps) =>
   (value: unknown) => {
+    const valueString = value?.toString()
+
     if (value === '' || value === undefined) {
       return true
     }
     if (timeIntervals === 0) {
       return 'Please enter a valid timeIntervals'
+    }
+    if (!valueString?.toString().includes('T')) {
+      return 'Invalid format. Use Date and Time separated by a space.'
     }
     const internalFormat = getDateFormat(dateFormat)
     // 1. Validate that it has date and time separated by space

--- a/src/ui/components/data-entry/date-time-picker/use-date-time-picker.tsx
+++ b/src/ui/components/data-entry/date-time-picker/use-date-time-picker.tsx
@@ -138,6 +138,13 @@ export const useDateTimePicker = ({
 
   const handleOnBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const inputValue = e.target.value
+    const currentValue = value ?? defaultValue ?? ''
+
+    if (!currentValue.toString().includes('T') || currentValue.toString().includes(' ')) {
+      onChange?.(createChangeEvent(inputValue))
+      onBlur?.(createBlurEvent(inputValue))
+      return
+    }
     if (!inputValue) {
       setDateTimeToDisplay(inputValue)
       onChange?.(createChangeEvent(''))

--- a/src/ui/components/data-entry/date-time-picker/utils.ts
+++ b/src/ui/components/data-entry/date-time-picker/utils.ts
@@ -297,6 +297,7 @@ export const parseDateTimeValueToInput = (
   is12HourFormat: boolean,
   timeIntervals: number
 ) => {
+  if (value && !value.toString().includes('T')) return value.toString()
   const datePart = getDateFromValue(value)
   const dateFormatted = parseInputString(datePart, dateFormat)
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

## Description
- When a value with an incorrect format passes through the value, it should show an error message (2025-02-01 10:23), Its not a valid ISO format when it's passed in the value field
- In the DateTime Field. Inserting time and date, e.g., 12:30 2025-08-12, and click outside/Submit. The error message related to the invalid format should appear. Initially, a message related to the date is visible, and after a few seconds, the error message changes. 