### PR TITLE
feat(scalars): add new format for the date-time-picker

### DIFF
--- a/src/scalars/components/date-time-picker-field/date-time-picker-field-validations.ts
+++ b/src/scalars/components/date-time-picker-field/date-time-picker-field-validations.ts
@@ -38,6 +38,10 @@ export const dateTimeFieldValidations =
     }
 
     const stringDate = normalizeMonthFormat(getDateFromValue(value as DateFieldValue))
+
+    if (stringDate.length === 4 && internalFormat === 'yyyy-MM-dd') {
+      return true
+    }
     const isValidFormat = isDateFormatAllowed(stringDate, internalFormat)
 
     if (!isValidFormat) {

--- a/src/scalars/components/date-time-picker-field/date-time-picker-field.stories.tsx
+++ b/src/scalars/components/date-time-picker-field/date-time-picker-field.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { FORMAT_MAPPING_DATE_TIME_PICKER } from '../../../ui/components/data-entry/date-time-picker/utils.js'
+import { FORMAT_MAPPING } from '../../../ui/components/data-entry/date-time-picker/utils.js'
 import { withForm } from '../../index.js'
 import { getDefaultArgTypes, getValidationArgTypes, StorybookControlCategory } from '../../lib/storybook-arg-types.js'
 import { DateTimePickerField } from './date-time-picker-field.js'
@@ -66,7 +66,7 @@ const meta: Meta<typeof DateTimePickerField> = {
         type: 'select',
       },
       description: 'The format of the date in the date picker',
-      options: Object.keys(FORMAT_MAPPING_DATE_TIME_PICKER),
+      options: Object.keys(FORMAT_MAPPING),
       table: {
         defaultValue: { summary: 'YYYY-MM-DD' },
         type: {

--- a/src/ui/components/data-entry/date-picker/subcomponents/month-grid.tsx
+++ b/src/ui/components/data-entry/date-picker/subcomponents/month-grid.tsx
@@ -33,7 +33,7 @@ const MonthGrid = ({
   const { goToMonth, months } = useDayPicker()
   const internalFormat = getDateFormat(dateFormat ?? '')
   const monthFormat = ['yyyy-MM', 'MM/yyyy', 'MM/yyyy', 'MMM-yyyy', 'YYYY'].includes(internalFormat ?? '')
-  const yearFormat = dateFormat === 'YYYY' && internalFormat === 'yyyy-MM-dd'
+  const yearFormat = dateFormat === 'YYYY'
   const actualYear = format(months[0].date, 'yyyy')
   const actualMonth = format(months[0].date, 'MMMM')
 

--- a/src/ui/components/data-entry/date-picker/use-date-picker.tsx
+++ b/src/ui/components/data-entry/date-picker/use-date-picker.tsx
@@ -34,6 +34,7 @@ export const useDatePickerField = ({
   maxDate,
 }: DatePickerFieldProps) => {
   const internalFormat = getDateFormat(dateFormat ?? '')
+  const yearFormat = dateFormat === 'YYYY'
   const [isOpen, setIsOpen] = React.useState(false)
   const [inputDisplay, setInputDisplay] = React.useState<string | undefined>(
     parseInputString(getDateFromValue(value ?? defaultValue ?? ''), internalFormat)
@@ -151,7 +152,6 @@ export const useDatePickerField = ({
   }, [value, internalFormat])
 
   const handleCalendarMonthYearSelect = (year: number, monthIndex: number) => {
-    const yearFormat = dateFormat === 'YYYY' && internalFormat === 'yyyy-MM-dd'
     const newInputValue = format(new Date(year, monthIndex), internalFormat ?? 'yyyy-MM-dd')
     const inputToShow = yearFormat ? `${year}` : newInputValue
     setInputDisplay(inputToShow)

--- a/src/ui/components/data-entry/date-time-picker/date-time-picker-content.tsx
+++ b/src/ui/components/data-entry/date-time-picker/date-time-picker-content.tsx
@@ -38,6 +38,8 @@ interface DateTimePickerContentProps {
   timeZone?: string
   onSave: () => void
   onCancel: () => void
+  dateFormat?: string
+  handleCalendarMonthYearSelect?: (year: number, monthIndex: number) => void
 }
 
 const DateTimePickerContent = ({
@@ -69,6 +71,8 @@ const DateTimePickerContent = ({
   selectedTimeZone,
   setSelectedTimeZone,
   timeZone,
+  dateFormat,
+  handleCalendarMonthYearSelect,
 }: DateTimePickerContentProps) => {
   return (
     <div className={cn('mx-auto w-full max-w-md', 'date-time-picker__content', className)}>
@@ -113,6 +117,8 @@ const DateTimePickerContent = ({
             onSelect={handleDateSelect}
             disabled={disabledDates}
             onDayClick={handleDayClick}
+            dateFormat={dateFormat}
+            handleCalendarMonthYearSelect={handleCalendarMonthYearSelect}
             className={cn(
               'w-full',
               'p-0',

--- a/src/ui/components/data-entry/date-time-picker/date-time-picker.stories.tsx
+++ b/src/ui/components/data-entry/date-time-picker/date-time-picker.stories.tsx
@@ -7,7 +7,7 @@ import {
   StorybookControlCategory,
 } from '../../../../scalars/lib/storybook-arg-types'
 import { DateTimePicker } from './date-time-picker.js'
-import { FORMAT_MAPPING_DATE_TIME_PICKER } from './utils.js'
+import { FORMAT_MAPPING } from './utils'
 
 /**
  * The `DateTimePicker` component provides an input field for selecting both dates and times.
@@ -200,7 +200,7 @@ const meta: Meta<typeof DateTimePicker> = {
         type: 'select',
       },
       description: 'The format of the date in the date picker',
-      options: Object.keys(FORMAT_MAPPING_DATE_TIME_PICKER),
+      options: Object.keys(FORMAT_MAPPING),
       table: {
         defaultValue: { summary: 'YYYY-MM-DD' },
         type: {

--- a/src/ui/components/data-entry/date-time-picker/date-time-picker.tsx
+++ b/src/ui/components/data-entry/date-time-picker/date-time-picker.tsx
@@ -113,6 +113,7 @@ const DateTimePicker = forwardRef<HTMLInputElement, DateTimePickerProps>(
       is12HourFormat,
       setSelectedTimeZone,
       isDisableSelect,
+      handleCalendarMonthYearSelect,
     } = useDateTimePicker({
       value,
       defaultValue,
@@ -192,6 +193,8 @@ const DateTimePicker = forwardRef<HTMLInputElement, DateTimePickerProps>(
               isDisableSelect={isDisableSelect}
               onCancel={onCancel}
               onSave={handleSave}
+              dateFormat={dateFormat}
+              handleCalendarMonthYearSelect={handleCalendarMonthYearSelect}
             />
           </BasePickerField>
           {description ? <FormDescription>{description}</FormDescription> : null}

--- a/src/ui/components/data-entry/date-time-picker/use-date-time-picker.tsx
+++ b/src/ui/components/data-entry/date-time-picker/use-date-time-picker.tsx
@@ -25,6 +25,7 @@ import {
   splitDateTimeStringFromInput,
   todayDateInput,
 } from './utils.js'
+import { format } from 'date-fns'
 
 interface DateTimeFieldProps {
   value?: DateFieldValue
@@ -78,9 +79,9 @@ export const useDateTimePicker = ({
 }: DateTimeFieldProps) => {
   const internalFormat = getDateFormat(dateFormat ?? '')
   const is12HourFormat = timeFormat.includes('a') || timeFormat.includes('A')
+  const isYearFormat = dateFormat === 'YYYY' && internalFormat === 'yyyy-MM-dd'
   const [isOpen, setIsOpen] = React.useState(false)
   const [activeTab, setActiveTab] = useState<'date' | 'time'>('date')
-
   const [dateTimeToDisplay, setDateTimeToDisplay] = useState(
     parseDateTimeValueToInput(value ?? defaultValue ?? '', internalFormat ?? '', is12HourFormat, timeIntervals)
   )
@@ -185,7 +186,7 @@ export const useDateTimePicker = ({
     }
     const timeFormat = formatInputsToValueFormat(hours, minutes, offsetUTC)
     const newValue = putTimeInValue(value ?? defaultValue ?? '', timeFormat)
-    const newVInput = newValue.split('T')[0]
+    const newVInput = isYearFormat ? newValue.split('T')[0].split('-')[0] : newValue.split('T')[0]
 
     // Check if the date is empty when split the value by T
     const valueEmptyDate = (value as string | undefined)?.split('T')[0] === ''
@@ -196,7 +197,7 @@ export const useDateTimePicker = ({
       return
     }
 
-    const valueFormatted = `${newVInput} ${datetimeFormatted}`
+    const valueFormatted = `${newVInput.toUpperCase()} ${datetimeFormatted}`
     setDateTimeToDisplay(valueFormatted)
     onChange?.(createChangeEvent(newValue))
     onBlur?.(createBlurEvent(newValue))
@@ -234,8 +235,10 @@ export const useDateTimePicker = ({
     }
     setDateTimeToDisplay(inputValue)
     const { date, time } = splitDateTimeStringFromInput(inputValue)
+    const datePartCorrected = isYearFormat ? new Date(Number(date), 0, 1).toISOString() : date
+    // const datePartCorrected = isYearFormat ? yearInput : date
     const offset = getOffset(timeZone ?? (selectedTimeZone as string))
-    let formattedDateTime = formatToISODateTimeWithOffset(date, time, offset)
+    let formattedDateTime = formatToISODateTimeWithOffset(datePartCorrected, time, offset)
     if (!time && !date) {
       formattedDateTime = inputValue
     }
@@ -304,14 +307,28 @@ export const useDateTimePicker = ({
     if (!isValid) {
       valueDate = todayDateInput(internalFormat)
     }
-    // Convert to uppercase for the value and for the input display
-    const upperValueDate = valueDate.toUpperCase()
 
+    const upperValueDate = valueDate.toUpperCase()
+    const upperValueDateYear = isYearFormat ? upperValueDate.split('-')[0] : upperValueDate
     const valueWithFormat = putDateInValue(newValue, upperValueDate)
-    const inputDisplay = `${upperValueDate} ${timeToDisplay}`
+    const inputDisplay = `${upperValueDateYear} ${timeToDisplay}`
     setDateTimeToDisplay(inputDisplay)
     onChange?.(createChangeEvent(valueWithFormat))
     onBlur?.(createBlurEvent(valueWithFormat))
+  }
+
+  const handleCalendarMonthYearSelect = (year: number, monthIndex: number) => {
+    const newInputValue = format(new Date(year, monthIndex), internalFormat ?? 'yyyy-MM-dd').toUpperCase()
+    const yearInput = new Date(year, 0, 1).toISOString()
+    const inputToShow = isYearFormat ? `${year}` : newInputValue
+    const newDateTime = putDateInValue(value ?? defaultValue ?? '', inputToShow)
+    const newValueDateTimeYear = putDateInValue(value ?? defaultValue ?? '', yearInput)
+    const newInputToShow = parseDateTimeValueToInput(newDateTime, internalFormat, is12HourFormat, timeIntervals)
+
+    const dateTimeISO = isYearFormat ? newValueDateTimeYear : newDateTime
+    setDateTimeToDisplay(newInputToShow.toUpperCase())
+    onChange?.(createChangeEvent(dateTimeISO))
+    setIsOpen(false)
   }
 
   return {
@@ -347,5 +364,6 @@ export const useDateTimePicker = ({
     setSelectedTimeZone,
     is12HourFormat,
     isDisableSelect,
+    handleCalendarMonthYearSelect,
   }
 }

--- a/src/ui/components/data-entry/date-time-picker/utils.ts
+++ b/src/ui/components/data-entry/date-time-picker/utils.ts
@@ -34,6 +34,7 @@ export const dateFormatRegexes = {
   'yyyy-MM': /^\d{4}-(0[1-9]|1[0-2])$/,
   'MM/yyyy': /^(0[1-9]|1[0-2])\/\d{4}$/,
   'MMM-yyyy': /^(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\d{4}$/,
+  yyyy: /^\d{4}$/,
 }
 
 /**
@@ -201,7 +202,7 @@ export const getDateFormat = (displayFormat: string): string | undefined => {
     case 'MMM-YYYY':
       return 'MMM-yyyy'
     case 'YYYY':
-      return 'yyyy-MM-dd'
+      return 'yyyy'
     default:
       return undefined
   }


### PR DESCRIPTION
## Ticket
- https://trello.com/c/HnZVa4UX/1063-add-month-year-and-year-only-selection-modes-to-the-datepicker

## Description
- The new date formats (YYYY-MM, MM/YYYY, MMM-YYYY, 2025-06, 06/2025, JUN-2025) should be visible for the DateTime picker. 