### PR TITLE
fix(scalars): add missing stories for url and add test for diff

### DIFF
--- a/src/scalars/components/url-field/url-field.stories.tsx
+++ b/src/scalars/components/url-field/url-field.stories.tsx
@@ -139,3 +139,29 @@ export const WithPlatformIcon: Story = {
     },
   },
 }
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'Number difference addition',
+    value: 'https://github.com/test',
+    baseValue: 'https://example.com',
+    viewMode: 'addition',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'Number difference removal',
+    value: 'https://google.com',
+    baseValue: 'https://example.com',
+    viewMode: 'removal',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'Number difference mixed',
+    value: 'https://google.com',
+    baseValue: 'https://github.com/test',
+    viewMode: 'mixed',
+  },
+}

--- a/src/scalars/components/url-field/url-field.test.tsx
+++ b/src/scalars/components/url-field/url-field.test.tsx
@@ -190,4 +190,58 @@ describe('UrlField', () => {
     await user.click(screen.getByTestId('reset-button'))
     expect(screen.queryByText('URL may be truncated')).toBeNull()
   })
+  describe('UrlField differences', () => {
+    it('should show value when viewMode is addition', () => {
+      renderWithForm(
+        <UrlField
+          data-testid="url-input-diff"
+          name="test-url"
+          label="Website URL"
+          value="https://github.com/test"
+          viewMode="addition"
+        />
+      )
+
+      const input = screen.getByTestId('url-input-diff')
+      expect(input).toBeInTheDocument()
+      expect(screen.getByText('https://github.com/test')).toBeInTheDocument()
+      expect(screen.queryByText('https://example.com')).not.toBeInTheDocument()
+    })
+
+    it('should show baseValue when viewMode is removal', () => {
+      renderWithForm(
+        <UrlField
+          data-testid="url-input-diff"
+          name="test-url"
+          label="Website URL"
+          value="https://github.com/test"
+          baseValue="https://example.com"
+          viewMode="removal"
+        />
+      )
+
+      const input = screen.getByTestId('url-input-diff')
+      expect(input).toBeInTheDocument()
+      expect(screen.queryByText('https://github.com/test')).not.toBeInTheDocument()
+      expect(screen.getByText('https://example.com')).toBeInTheDocument()
+    })
+
+    it('should show value and baseValue when viewMode is mixed', () => {
+      renderWithForm(
+        <UrlField
+          data-testid="url-input-diff"
+          name="test-url"
+          label="Website URL"
+          value="https://github.com/test"
+          baseValue="https://example.com"
+          viewMode="mixed"
+        />
+      )
+
+      const input = screen.getByTestId('url-input-diff')
+      expect(input).toBeInTheDocument()
+      expect(screen.getByText('https://github.com/test')).toBeInTheDocument()
+      expect(screen.getByText('https://example.com')).toBeInTheDocument()
+    })
+  })
 })

--- a/src/ui/components/data-entry/url-input/url-input-diff.tsx
+++ b/src/ui/components/data-entry/url-input/url-input-diff.tsx
@@ -10,7 +10,15 @@ interface UrlInputDiffProps extends UrlInputWithDifference {
   platformIcons: UrlInputProps['platformIcons']
 }
 
-const UrlInputDiff = ({ value = '', label, required, viewMode, baseValue = '', platformIcons }: UrlInputDiffProps) => {
+const UrlInputDiff = ({
+  value = '',
+  label,
+  required,
+  viewMode,
+  baseValue = '',
+  platformIcons,
+  ...props
+}: UrlInputDiffProps) => {
   return (
     <FormGroup>
       {label && (
@@ -25,6 +33,7 @@ const UrlInputDiff = ({ value = '', label, required, viewMode, baseValue = '', p
         diffMode="sentences"
         asLink={true}
         platformIcons={platformIcons}
+        {...props}
       />
     </FormGroup>
   )

--- a/src/ui/components/data-entry/url-input/url-input.stories.tsx
+++ b/src/ui/components/data-entry/url-input/url-input.stories.tsx
@@ -153,3 +153,30 @@ export const WithPlatformIcon: Story = {
     },
   },
 }
+
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'Number difference addition',
+    value: 'https://github.com/test',
+    baseValue: 'https://example.com',
+    viewMode: 'addition',
+  },
+}
+
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'Number difference removal',
+    value: 'https://google.com',
+    baseValue: 'https://example.com',
+    viewMode: 'removal',
+  },
+}
+
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'Number difference mixed',
+    value: 'https://google.com',
+    baseValue: 'https://github.com/test',
+    viewMode: 'mixed',
+  },
+}

--- a/src/ui/components/data-entry/url-input/url-input.tsx
+++ b/src/ui/components/data-entry/url-input/url-input.tsx
@@ -127,6 +127,7 @@ const UrlInput = React.forwardRef<HTMLInputElement, UrlInputProps>(
         viewMode={viewMode}
         baseValue={baseValue}
         platformIcons={platformIcons}
+        data-testid="url-input-diff"
       />
     )
   }


### PR DESCRIPTION
## Ticket
- https://trello.com/c/oxAOKsO1/1072-diff-status-comparison-stories-are-missing-in-multiples-components


## Description
- Should the diff comparison status for URL be reflected as stories? Add some for the difference  and test the component