### PR TITLE
fix(scalars): fix issue when for year format and mock the date test

### DIFF
--- a/src/scalars/components/date-picker-field/date-picker-field.test.tsx
+++ b/src/scalars/components/date-picker-field/date-picker-field.test.tsx
@@ -11,11 +11,23 @@ export const getRelativeDate = (daysFromToday: number) => {
 }
 
 describe('DatePickerField', () => {
+  const fixedDate = new Date('2025-01-01T12:00:00Z')
+
+  beforeEach(() => {
+    vi.setSystemTime(fixedDate)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
   const defaultProps = {
     name: 'test-date',
     label: 'Test Label',
   }
-
+  it('should mock the system date to fixedDate', () => {
+    const now = new Date()
+    expect(now.toISOString()).toBe(fixedDate.toISOString())
+  })
   it('should match the snapshot', () => {
     const { container } = renderWithForm(
       <DatePickerField {...defaultProps} value="2025-01-01" dateFormat="yyyy-MM-dd" />
@@ -118,5 +130,14 @@ describe('DatePickerField', () => {
 
     // Assert: Error message is shown
     expect(screen.getByText(/Date must be before/i)).toBeInTheDocument()
+  })
+
+  it('should show error when its valid for(YYYY) and format its undefined', async () => {
+    renderWithForm(<DatePickerField {...defaultProps} showErrorOnBlur />)
+
+    const input = screen.getByRole('textbox')
+    await userEvent.type(input, '3455')
+    await userEvent.tab()
+    expect(screen.getByText(/Invalid date format. Please use a valid format/i)).toBeInTheDocument()
   })
 })

--- a/src/ui/components/data-entry/date-picker/date-picker.test.tsx
+++ b/src/ui/components/data-entry/date-picker/date-picker.test.tsx
@@ -8,11 +8,26 @@ export const getRelativeDate = (daysFromToday: number) => {
   const date = addDays(new Date(), daysFromToday)
   return format(date, 'yyyy-MM-dd')
 }
+
+const fixedDate = new Date('2025-01-01T12:00:00Z')
+
+beforeEach(() => {
+  vi.setSystemTime(fixedDate)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
 describe('DatePicker', () => {
   const defaultProps = {
     name: 'test-date',
     label: 'Test Date',
   }
+  it('should mock the system date to fixedDate', () => {
+    const now = new Date()
+    expect(now.toISOString()).toBe(fixedDate.toISOString())
+  })
 
   it('should match the snapshot', () => {
     const { container } = render(
@@ -174,8 +189,13 @@ describe('DatePicker', () => {
     // Act: Open calendar and select date
     const calendarButton = screen.getByTestId('icon-fallback').closest('button')
     await userEvent.click(calendarButton!)
+
+    const newDate = new Date(fixedDate)
+    // We Get next day of the mockDate (fixedDate) that will always be in the calendar
+    newDate.setDate(newDate.getDate() + 1)
+    // We format the date to the expected format
     const dateButton = screen.getByRole('button', {
-      name: 'Sunday, June 29th, 2025',
+      name: format(newDate, 'EEEE, MMMM do, yyyy'),
     })
     await userEvent.click(dateButton)
 
@@ -243,8 +263,8 @@ describe('DatePicker', () => {
       expect(screen.getByTestId('date-picker-diff')).toBeInTheDocument()
       const iconFallbacks = screen.getAllByTestId('icon-fallback')
       expect(iconFallbacks).toHaveLength(2)
-      expect(screen.getByText('01/01/2024')).toBeInTheDocument()
-      expect(screen.getByText('01/01/2025')).toBeInTheDocument()
+      expect(screen.getByText('2024-01-01')).toBeInTheDocument()
+      expect(screen.getByText('2025-01-01')).toBeInTheDocument()
     })
 
     it('should not render DateInputDiff when viewMode is edition', () => {

--- a/src/ui/components/data-entry/date-time-picker/use-date-time-picker.tsx
+++ b/src/ui/components/data-entry/date-time-picker/use-date-time-picker.tsx
@@ -79,7 +79,7 @@ export const useDateTimePicker = ({
 }: DateTimeFieldProps) => {
   const internalFormat = getDateFormat(dateFormat ?? '')
   const is12HourFormat = timeFormat.includes('a') || timeFormat.includes('A')
-  const isYearFormat = dateFormat === 'YYYY' && internalFormat === 'yyyy-MM-dd'
+  const isYearFormat = dateFormat === 'YYYY'
   const [isOpen, setIsOpen] = React.useState(false)
   const [activeTab, setActiveTab] = useState<'date' | 'time'>('date')
   const [dateTimeToDisplay, setDateTimeToDisplay] = useState(

--- a/src/ui/components/data-entry/date-time-picker/utils.ts
+++ b/src/ui/components/data-entry/date-time-picker/utils.ts
@@ -105,7 +105,7 @@ export const getOffset = (timeZone?: string) => {
 
     if (!offsetPart) return getLocalOffset()
     const offsetMatch =
-      /^(?:GMT|UTC)?([+-])(\d{1,2})(?::?(\d{2}))?/i.exec(offsetPart) || /(UTC|GMT)([+-]\d{2}:\d{2})/.exec(offsetPart)
+      /^(?:GMT|UTC)?([+-])(\d{1,2})(?::?(\d{2}))?/i.exec(offsetPart) ?? /(UTC|GMT)([+-]\d{2}:\d{2})/.exec(offsetPart)
 
     if (!offsetMatch) return getLocalOffset()
     const sign = offsetMatch[1] || '+'
@@ -183,7 +183,7 @@ export const FORMAT_MAPPING_DATE_TIME_PICKER = {
   'MMM-DD-YYYY': 'MMM-dd-yyyy',
 }
 
-export const getDateFormat = (displayFormat: string): string | undefined => {
+export const getDateFormat = (displayFormat: string): string => {
   switch (displayFormat) {
     case 'YYYY-MM-DD':
       return 'yyyy-MM-dd'
@@ -204,7 +204,7 @@ export const getDateFormat = (displayFormat: string): string | undefined => {
     case 'YYYY':
       return 'yyyy'
     default:
-      return undefined
+      return 'yyyy-MM-dd'
   }
 }
 


### PR DESCRIPTION
## Ticket
- https://trello.com/c/SMGtrk6b/795-3-datetimefield-date-datetime-time

## Description
- DatePicker. Inserting 4 digits, e.g. 1123 and clicking outside/Submit. The field should not support these 4 digits as a year. The value is sent representing a year