### PR TITLE
feat(scalars): allow null in email scalars

### DIFF
--- a/src/scalars/graphql/test/EmailAddress.test.ts
+++ b/src/scalars/graphql/test/EmailAddress.test.ts
@@ -70,4 +70,11 @@ describe('EmailAddress Scalar', () => {
       })
     ).toThrow()
   })
+  it('debería renderizar correctamente y sin errores cuando el valor es null', () => {
+    expect(() =>
+      scalar.parseLiteral({
+        kind: Kind.NULL,
+      })
+    ).not.toThrow()
+  })
 })


### PR DESCRIPTION
## Ticket
- https://trello.com/c/Hl5iClSo/1078-16-email

## Description
- Should the Scalars be updated to allow Null . At the moment the scalar only accepts  string