### PR TITLE
fix(scalars): filter values that had ticker and cripto properties

### DIFF
--- a/src/ui/components/data-entry/amount-input/use-amount-input.tsx
+++ b/src/ui/components/data-entry/amount-input/use-amount-input.tsx
@@ -146,7 +146,7 @@ export const useAmountInput = ({
   }, [inputFocused, type, baseValue, precision, viewPrecision, trailingZeros, rawAmountState])
 
   const isPercent = type === 'AmountPercentage'
-  const isAmountWithUnit = type === 'Amount' && typeof value === 'object' && 'unit' in value
+  const isAmountWithUnit = type === 'Amount' && value && typeof value === 'object' && 'unit' in value
   const isAmountWithoutUnit = type === 'Amount' && !isAmountWithUnit
 
   const isShowSelect =

--- a/src/ui/components/data-entry/currency-code-picker/currency-code-picker.tsx
+++ b/src/ui/components/data-entry/currency-code-picker/currency-code-picker.tsx
@@ -31,8 +31,8 @@ const CurrencyCodePicker = React.forwardRef<HTMLButtonElement, CurrencyCodePicke
     const defaultCurrencies = currencies.length > 0 ? currencies : getCurrencies(allowedTypes)
     const options: SelectOption[] = useMemo(() => {
       const favoriteTickers = new Set(favoriteCurrencies)
-
       return defaultCurrencies
+        .filter((currency) => currency.ticker && typeof currency.crypto === 'boolean')
         .map((currency) => {
           if (favoriteTickers.has(currency.ticker)) {
             return null


### PR DESCRIPTION
## Ticket
- https://trello.com/c/Y2sFr9aM/1086-storybook-breaks-after-adding-a-currency-name

## Description
- Should the field works properly when a currency name is added in the prop. Add the moment for the story book, add new currency without correct type, broken the UI.

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
<img width="1479" alt="image" src="https://github.com/user-attachments/assets/29f54213-a627-4552-a9b8-55c37a86ee1e" />
