### PR TITLE
feat(scalars): add diff for simple value in email component

### DIFF
--- a/src/scalars/components/email-field/email-field.stories.tsx
+++ b/src/scalars/components/email-field/email-field.stories.tsx
@@ -28,6 +28,8 @@ const meta: Meta<typeof EmailField> = {
     ...PrebuiltArgTypes.minLength,
     ...PrebuiltArgTypes.maxLength,
     ...PrebuiltArgTypes.pattern,
+    ...PrebuiltArgTypes.viewMode,
+    ...PrebuiltArgTypes.baseValue,
     allowedDomains: {
       control: 'object',
       description: 'Allowed domains for the email field',
@@ -57,5 +59,30 @@ export const Filled: Story = {
     label: 'Email Input',
     placeholder: 'Enter your email',
     value: 'john.doe@example.com',
+  },
+}
+
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'Number difference addition',
+    value: 'test@gmail.com',
+    baseValue: 'other@example.com',
+    viewMode: 'addition',
+  },
+}
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'Date difference removal',
+    value: 'test@gmail.com',
+    baseValue: 'test@example.com',
+    viewMode: 'removal',
+  },
+}
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'Date difference mixed',
+    value: 'other@example.com',
+    baseValue: 'test@example.com',
+    viewMode: 'mixed',
   },
 }

--- a/src/scalars/components/email-field/email-field.test.tsx
+++ b/src/scalars/components/email-field/email-field.test.tsx
@@ -89,4 +89,38 @@ describe('EmailField', () => {
     expect(screen.queryByText('Email domain must be one of: example.com, company.org')).not.toBeInTheDocument()
     expect(input).toHaveValue('test@company.org')
   })
+  describe('EmailField differences', () => {
+    it('should show value when viewMode is addition', () => {
+      renderWithForm(
+        <EmailField value="test@example.com" baseValue="other@example.com" viewMode="addition" name="Label" />
+      )
+
+      const input = screen.getByTestId('email-input-diff')
+      expect(input).toBeInTheDocument()
+      expect(screen.getByText('test@example.com')).toBeInTheDocument()
+      expect(screen.queryByText('other@example.com')).not.toBeInTheDocument()
+    })
+
+    it('should show baseValue when viewMode is removal', () => {
+      renderWithForm(
+        <EmailField value="test@example.com" baseValue="other@example.com" viewMode="removal" name="Label" />
+      )
+
+      const input = screen.getByTestId('email-input-diff')
+      expect(input).toBeInTheDocument()
+      expect(screen.queryByText('test@example.com')).not.toBeInTheDocument()
+      expect(screen.getByText('other@example.com')).toBeInTheDocument()
+    })
+
+    it('should show value and baseValue when viewMode is mixed', () => {
+      renderWithForm(
+        <EmailField value="test@example.com" baseValue="other@example.com" viewMode="mixed" name="Label" />
+      )
+
+      const input = screen.getByTestId('email-input-diff')
+      expect(input).toBeInTheDocument()
+      expect(screen.getByText('test@example.com')).toBeInTheDocument()
+      expect(screen.getByText('other@example.com')).toBeInTheDocument()
+    })
+  })
 })

--- a/src/ui/components/data-entry/email-input/email-input.stories.tsx
+++ b/src/ui/components/data-entry/email-input/email-input.stories.tsx
@@ -63,3 +63,28 @@ export const Filled: Story = {
     value: 'test@example.com',
   },
 }
+
+export const WithDifferencesAddition: Story = {
+  args: {
+    label: 'Number difference addition',
+    value: 'test@gmail.com',
+    baseValue: 'other@example.com',
+    viewMode: 'addition',
+  },
+}
+export const WithDifferencesRemoval: Story = {
+  args: {
+    label: 'Date difference removal',
+    value: 'test@gmail.com',
+    baseValue: 'test@example.com',
+    viewMode: 'removal',
+  },
+}
+export const WithDifferencesMixed: Story = {
+  args: {
+    label: 'Date difference mixed',
+    value: 'other@example.com',
+    baseValue: 'test@example.com',
+    viewMode: 'mixed',
+  },
+}

--- a/src/ui/components/data-entry/email-input/email-input.tsx
+++ b/src/ui/components/data-entry/email-input/email-input.tsx
@@ -7,6 +7,7 @@ import { Input } from '../input/index.js'
 import type { EmailInputProps } from './types.js'
 import { useUniqueId } from '../../../../scalars/lib/utils.js'
 import useControllableState from '../../../hooks/use-controllable-state.js'
+import { SplittedInputDiff } from '../input/splitted-input-diff.js'
 
 const EmailInput = React.forwardRef<HTMLInputElement, EmailInputProps>(
   (
@@ -24,6 +25,8 @@ const EmailInput = React.forwardRef<HTMLInputElement, EmailInputProps>(
       id: propId,
       onChange,
       onBlur,
+      baseValue,
+      viewMode = 'edition',
       ...props
     },
     ref
@@ -43,29 +46,39 @@ const EmailInput = React.forwardRef<HTMLInputElement, EmailInputProps>(
       () => Object.fromEntries(Object.entries(props).filter(([key]) => key !== 'maxLength')),
       [props]
     )
-
+    if (viewMode === 'edition') {
+      return (
+        <FormGroup>
+          <FormLabel htmlFor={id} required={required} disabled={disabled} hasError={!!errors?.length}>
+            {label}
+          </FormLabel>
+          <Input
+            name={name}
+            value={emailValue ?? ''}
+            onChange={handleChange}
+            onBlur={onBlur}
+            disabled={disabled}
+            id={id}
+            type="email"
+            autoComplete={autoCompleteValue}
+            required={required}
+            ref={ref}
+            {...filteredProps}
+          />
+          {description && <FormDescription>{description}</FormDescription>}
+          {warnings && <FormMessageList messages={warnings} type="warning" />}
+          {errors && <FormMessageList messages={errors} type="error" />}
+        </FormGroup>
+      )
+    }
     return (
-      <FormGroup>
-        <FormLabel htmlFor={id} required={required} disabled={disabled} hasError={!!errors?.length}>
-          {label}
-        </FormLabel>
-        <Input
-          name={name}
-          value={emailValue ?? ''}
-          onChange={handleChange}
-          onBlur={onBlur}
-          disabled={disabled}
-          id={id}
-          type="email"
-          autoComplete={autoCompleteValue}
-          required={required}
-          ref={ref}
-          {...filteredProps}
-        />
-        {description && <FormDescription>{description}</FormDescription>}
-        {warnings && <FormMessageList messages={warnings} type="warning" />}
-        {errors && <FormMessageList messages={errors} type="error" />}
-      </FormGroup>
+      <SplittedInputDiff
+        baseValue={baseValue}
+        value={emailValue ?? ''}
+        viewMode={viewMode}
+        diffMode="sentences"
+        data-testid="email-input-diff"
+      />
     )
   }
 )

--- a/src/ui/components/data-entry/email-input/types.ts
+++ b/src/ui/components/data-entry/email-input/types.ts
@@ -1,4 +1,4 @@
-import type { InputBaseProps } from '../../../../scalars/components/types.js'
+import type { InputBaseProps, WithDifference } from '../../../../scalars/components/types.js'
 import type { InputHTMLAttributes } from 'react'
 
 export interface EmailInputProps
@@ -6,6 +6,7 @@ export interface EmailInputProps
       InputHTMLAttributes<HTMLInputElement>,
       'value' | 'defaultValue' | 'autoComplete' | 'pattern' | 'minLength' | 'maxLength'
     >,
+    Omit<WithDifference<string>, 'diffMode'>,
     InputBaseProps<string> {
   placeholder?: string
   autoComplete?: boolean


### PR DESCRIPTION
## Ticket
https://trello.com/c/Hl5iClSo/1078-16-email

## Description
- Read only - diff comparison status  stories
- Should set the **Default** as a String/Null. ( A default email value if one is provided, or null if there is no default)
- Should ensure the Value is the current email address entered by the user, or null if not set. Validate the email 

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
