### PR TITLE
feat(scalars): add field match function and add test

### DIFF
--- a/src/scalars/components/email-field/__snapshots__/email-field.test.tsx.snap
+++ b/src/scalars/components/email-field/__snapshots__/email-field.test.tsx.snap
@@ -17,6 +17,8 @@ exports[`EmailField > should match snapshot 1`] = `
       </label>
       <input
         class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300"
+        data-exclude="true"
+        data-label="Test Label"
         id=":r1:-email"
         name="test"
         type="email"

--- a/src/scalars/components/email-field/email-field.stories.tsx
+++ b/src/scalars/components/email-field/email-field.stories.tsx
@@ -90,8 +90,15 @@ export const WithDifferencesMixed: Story = {
 export const WithEmailMatchForm: Story = {
   render: () => (
     <div className="flex flex-col gap-4">
-      <EmailField label="Email" name="email" placeholder="Enter your email" />
-      <EmailField label="Confirm Email" name="confirmEmail" placeholder="Confirm your email" matchFieldName="email" />
+      <EmailField label="Email" name="email" placeholder="Enter your email" key="email" />
+      <EmailField
+        label="Confirm Email"
+        name="confirmEmail"
+        placeholder="Confirm your email"
+        matchFieldName="email"
+        matchFieldLabelError="Email"
+        key="confirmEmail"
+      />
     </div>
   ),
 }

--- a/src/scalars/components/email-field/email-field.stories.tsx
+++ b/src/scalars/components/email-field/email-field.stories.tsx
@@ -86,3 +86,12 @@ export const WithDifferencesMixed: Story = {
     viewMode: 'mixed',
   },
 }
+
+export const WithEmailMatchForm: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <EmailField label="Email" name="email" placeholder="Enter your email" />
+      <EmailField label="Confirm Email" name="confirmEmail" placeholder="Confirm your email" matchFieldName="email" />
+    </div>
+  ),
+}

--- a/src/scalars/components/email-field/email-field.stories.tsx
+++ b/src/scalars/components/email-field/email-field.stories.tsx
@@ -39,6 +39,14 @@ const meta: Meta<typeof EmailField> = {
         category: StorybookControlCategory.VALIDATION,
       },
     },
+    matchFieldName: {
+      control: 'text',
+      description: 'Name of the field to match',
+      table: {
+        type: { summary: 'string' },
+        category: StorybookControlCategory.VALIDATION,
+      },
+    },
   },
   args: {
     name: 'email-field',
@@ -90,15 +98,8 @@ export const WithDifferencesMixed: Story = {
 export const WithEmailMatchForm: Story = {
   render: () => (
     <div className="flex flex-col gap-4">
-      <EmailField label="Email" name="email" placeholder="Enter your email" key="email" />
-      <EmailField
-        label="Confirm Email"
-        name="confirmEmail"
-        placeholder="Confirm your email"
-        matchFieldName="email"
-        matchFieldLabelError="Email"
-        key="confirmEmail"
-      />
+      <EmailField label="Email Address" name="email" placeholder="Enter your email" />
+      <EmailField label="Confirm Email" name="confirmEmail" placeholder="Confirm your email" matchFieldName="email" />
     </div>
   ),
 }

--- a/src/scalars/components/email-field/email-field.test.tsx
+++ b/src/scalars/components/email-field/email-field.test.tsx
@@ -143,13 +143,39 @@ describe('EmailField', () => {
     renderWithForm(
       <div>
         <EmailField label="Email" name="email" showErrorOnBlur value="example@example.com" />
-        <EmailField label="Confirm Email" name="confirmEmail" matchFieldName="email" showErrorOnBlur />
+        <EmailField
+          label="Confirm Email"
+          name="confirmEmail"
+          matchFieldName="email"
+          matchFieldLabelError="Email"
+          showErrorOnBlur
+        />
+      </div>
+    )
+    const input = screen.getByRole('textbox', { name: 'Confirm Email' })
+    await userEvent.type(input, 'test@example.com')
+    await userEvent.tab()
+    const errorMessage = screen.getByText('Email must match the Email field')
+    expect(errorMessage).toBeInTheDocument()
+  })
+
+  it('should use matchFieldLabel in error message when provided', async () => {
+    renderWithForm(
+      <div>
+        <EmailField label="Email Address" name="email" showErrorOnBlur value="example@example.com" />
+        <EmailField
+          label="Confirm Email"
+          name="confirmEmail"
+          matchFieldName="email"
+          matchFieldLabelError="Email"
+          showErrorOnBlur
+        />
       </div>
     )
     const input = screen.getByRole('textbox', { name: 'Confirm Email' })
     await userEvent.type(input, 'test@example.com')
     await userEvent.tab()
 
-    expect(screen.queryByText('Email must match the email field')).toBeInTheDocument()
+    expect(screen.queryByText('Email must match the Email field')).toBeInTheDocument()
   })
 })

--- a/src/scalars/components/email-field/email-field.test.tsx
+++ b/src/scalars/components/email-field/email-field.test.tsx
@@ -123,4 +123,33 @@ describe('EmailField', () => {
       expect(screen.getByText('other@example.com')).toBeInTheDocument()
     })
   })
+
+  it('should not show error when emails match', async () => {
+    renderWithForm(
+      <div>
+        <EmailField label="Email" name="email" value="test@example.com" />
+        <EmailField label="Confirm Email" name="confirmEmail" matchFieldName="email" showErrorOnBlur />
+      </div>
+    )
+
+    const input = screen.getByRole('textbox', { name: 'Confirm Email' })
+    await userEvent.type(input, 'test@example.com')
+    await userEvent.tab()
+
+    expect(screen.queryByText('Email must match the email field')).not.toBeInTheDocument()
+  })
+
+  it('should not validate match when matchFieldName is not provided', async () => {
+    renderWithForm(
+      <div>
+        <EmailField label="Email" name="email" showErrorOnBlur value="example@example.com" />
+        <EmailField label="Confirm Email" name="confirmEmail" matchFieldName="email" showErrorOnBlur />
+      </div>
+    )
+    const input = screen.getByRole('textbox', { name: 'Confirm Email' })
+    await userEvent.type(input, 'test@example.com')
+    await userEvent.tab()
+
+    expect(screen.queryByText('Email must match the email field')).toBeInTheDocument()
+  })
 })

--- a/src/scalars/components/email-field/email-field.test.tsx
+++ b/src/scalars/components/email-field/email-field.test.tsx
@@ -143,13 +143,7 @@ describe('EmailField', () => {
     renderWithForm(
       <div>
         <EmailField label="Email" name="email" showErrorOnBlur value="example@example.com" />
-        <EmailField
-          label="Confirm Email"
-          name="confirmEmail"
-          matchFieldName="email"
-          matchFieldLabelError="Email"
-          showErrorOnBlur
-        />
+        <EmailField label="Confirm Email" name="confirmEmail" matchFieldName="email" showErrorOnBlur />
       </div>
     )
     const input = screen.getByRole('textbox', { name: 'Confirm Email' })
@@ -163,19 +157,13 @@ describe('EmailField', () => {
     renderWithForm(
       <div>
         <EmailField label="Email Address" name="email" showErrorOnBlur value="example@example.com" />
-        <EmailField
-          label="Confirm Email"
-          name="confirmEmail"
-          matchFieldName="email"
-          matchFieldLabelError="Email"
-          showErrorOnBlur
-        />
+        <EmailField label="Confirm Email" name="confirmEmail" matchFieldName="email" showErrorOnBlur />
       </div>
     )
     const input = screen.getByRole('textbox', { name: 'Confirm Email' })
     await userEvent.type(input, 'test@example.com')
     await userEvent.tab()
-
-    expect(screen.queryByText('Email must match the Email field')).toBeInTheDocument()
+    const errorMessage = screen.getByText('Email must match the Email Address field')
+    expect(errorMessage).toBeInTheDocument()
   })
 })

--- a/src/scalars/components/email-field/email-field.tsx
+++ b/src/scalars/components/email-field/email-field.tsx
@@ -3,7 +3,7 @@ import type { EmailInputProps } from '../../../ui/components/data-entry/email-in
 import { validateFieldMatch } from '../../lib/validators/validateFieldMatch.js'
 import { withFieldValidation } from '../fragments/with-field-validation/index.js'
 import type { FieldErrorHandling } from '../types.js'
-import { validateEmailDomain, validateEmailFormat } from './utils.js'
+import { escapeIdForSelector, validateEmailDomain, validateEmailFormat } from './utils.js'
 
 type EmailFieldProps = Omit<EmailInputProps, 'maxLength' | 'minLength'> &
   FieldErrorHandling & {
@@ -27,10 +27,18 @@ const EmailField = withFieldValidation<EmailFieldProps>(EmailInput, {
       ({ matchFieldName }) =>
       (value: string, formState: Record<string, unknown>) => {
         if (!matchFieldName) return true
+        const currentField = document.querySelector(`input[name="${matchFieldName}"]`)
+        const form = currentField?.closest('form')
+        const formId = form?.id
 
-        const matchFieldSelector = `input[name="${matchFieldName}"]`
+        const matchFieldSelector = formId
+          ? `#${escapeIdForSelector(formId)} input[name="${matchFieldName}"]`
+          : `input[name="${matchFieldName}"]`
+        const matchFieldElement = document.querySelector(matchFieldSelector)
 
-        const matchFieldLabel = document.querySelector(matchFieldSelector)?.getAttribute('data-label') ?? ''
+        if (!matchFieldElement) return true
+
+        const matchFieldLabel = matchFieldElement.getAttribute('data-label') ?? ''
 
         return validateFieldMatch(value, formState, {
           matchFieldName,

--- a/src/scalars/components/email-field/email-field.tsx
+++ b/src/scalars/components/email-field/email-field.tsx
@@ -9,6 +9,7 @@ type EmailFieldProps = Omit<EmailInputProps, 'maxLength' | 'minLength'> &
   FieldErrorHandling & {
     allowedDomains?: string[]
     matchFieldName?: string
+    matchFieldLabelError?: string
   }
 
 const EmailField = withFieldValidation<EmailFieldProps>(EmailInput, {
@@ -24,11 +25,12 @@ const EmailField = withFieldValidation<EmailFieldProps>(EmailInput, {
         return validateEmailDomain(value, { allowedDomains })
       },
     _matchEmail:
-      ({ matchFieldName }) =>
+      ({ matchFieldName, matchFieldLabelError }) =>
       (value: string, formState: Record<string, unknown>) => {
         return validateFieldMatch(value, formState, {
           matchFieldName,
-          errorMessage: `Email must match the ${matchFieldName} field`,
+          errorMessage: `Email must match the ${matchFieldLabelError} field`,
+          matchFieldLabelError,
         })
       },
   },

--- a/src/scalars/components/email-field/email-field.tsx
+++ b/src/scalars/components/email-field/email-field.tsx
@@ -1,5 +1,6 @@
 import { EmailInput } from '../../../ui/components/data-entry/email-input/index.js'
 import type { EmailInputProps } from '../../../ui/components/data-entry/email-input/types.js'
+import { validateFieldMatch } from '../../lib/validators/validateFieldMatch.js'
 import { withFieldValidation } from '../fragments/with-field-validation/index.js'
 import type { FieldErrorHandling } from '../types.js'
 import { validateEmailDomain, validateEmailFormat } from './utils.js'
@@ -7,6 +8,7 @@ import { validateEmailDomain, validateEmailFormat } from './utils.js'
 type EmailFieldProps = Omit<EmailInputProps, 'maxLength' | 'minLength'> &
   FieldErrorHandling & {
     allowedDomains?: string[]
+    matchFieldName?: string
   }
 
 const EmailField = withFieldValidation<EmailFieldProps>(EmailInput, {
@@ -20,6 +22,14 @@ const EmailField = withFieldValidation<EmailFieldProps>(EmailInput, {
       (value: string) => {
         if (!value) return true
         return validateEmailDomain(value, { allowedDomains })
+      },
+    _matchEmail:
+      ({ matchFieldName }) =>
+      (value: string, formState: Record<string, unknown>) => {
+        return validateFieldMatch(value, formState, {
+          matchFieldName,
+          errorMessage: `Email must match the ${matchFieldName} field`,
+        })
       },
   },
 })

--- a/src/scalars/components/email-field/email-field.tsx
+++ b/src/scalars/components/email-field/email-field.tsx
@@ -9,7 +9,6 @@ type EmailFieldProps = Omit<EmailInputProps, 'maxLength' | 'minLength'> &
   FieldErrorHandling & {
     allowedDomains?: string[]
     matchFieldName?: string
-    matchFieldLabelError?: string
   }
 
 const EmailField = withFieldValidation<EmailFieldProps>(EmailInput, {
@@ -25,12 +24,17 @@ const EmailField = withFieldValidation<EmailFieldProps>(EmailInput, {
         return validateEmailDomain(value, { allowedDomains })
       },
     _matchEmail:
-      ({ matchFieldName, matchFieldLabelError }) =>
+      ({ matchFieldName }) =>
       (value: string, formState: Record<string, unknown>) => {
+        if (!matchFieldName) return true
+
+        const matchFieldSelector = `input[name="${matchFieldName}"]`
+
+        const matchFieldLabel = document.querySelector(matchFieldSelector)?.getAttribute('data-label') ?? ''
+
         return validateFieldMatch(value, formState, {
           matchFieldName,
-          errorMessage: `Email must match the ${matchFieldLabelError} field`,
-          matchFieldLabelError,
+          errorMessage: `Email must match the ${matchFieldLabel} field`,
         })
       },
   },

--- a/src/scalars/components/email-field/utils.ts
+++ b/src/scalars/components/email-field/utils.ts
@@ -37,3 +37,7 @@ export const validateEmailDomain = (value: string, options: DomainValidationOpti
 
   return isAllowed || `Email domain must be one of: ${options.allowedDomains.join(', ')}`
 }
+
+export const escapeIdForSelector = (id: string): string => {
+  return id.replace(/[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g, '\\$&')
+}

--- a/src/scalars/components/form/form.test.tsx
+++ b/src/scalars/components/form/form.test.tsx
@@ -3,6 +3,7 @@ import { userEvent } from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { StringField } from '../string-field/index.js'
 import { Form } from './form.js'
+import { EmailField } from '../email-field/email-field.js'
 
 describe('Form', () => {
   it('should render children as React nodes', () => {
@@ -115,5 +116,48 @@ describe('Form', () => {
       </Form>
     )
     expect(screen.getByText('Test')).toHaveClass('test-class')
+  })
+
+  describe('EmailField with matchFieldName', () => {
+    it('should not submit field when it has matchFieldName and data-exclude attributes', async () => {
+      const handleSubmit = vi.fn()
+
+      render(
+        <Form onSubmit={handleSubmit}>
+          <EmailField name="email" value="test@example.com" />
+          <EmailField name="confirmEmail" matchFieldName="email" value="test@example.com" />
+          <button type="submit">Submit</button>
+        </Form>
+      )
+
+      fireEvent.click(screen.getByText('Submit'))
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith({
+          email: 'test@example.com',
+        })
+      })
+    })
+
+    it('should submit both fields when matchFieldName is not provided', async () => {
+      const handleSubmit = vi.fn()
+
+      render(
+        <Form onSubmit={handleSubmit}>
+          <EmailField name="email" value="test@example.com" />
+          <EmailField name="confirmEmail" value="test@example.com" />
+          <button type="submit">Submit</button>
+        </Form>
+      )
+
+      fireEvent.click(screen.getByText('Submit'))
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith({
+          email: 'test@example.com',
+          confirmEmail: 'test@example.com',
+        })
+      })
+    })
   })
 })

--- a/src/scalars/components/form/form.tsx
+++ b/src/scalars/components/form/form.tsx
@@ -188,6 +188,12 @@ const Form = forwardRef<UseFormReturn, FormProps>(
               if (value !== null) {
                 const field = form?.querySelector(`[name="${key}"]`)
                 const dataCast = field?.getAttribute('data-cast')
+                const fieldToExclude = field?.getAttribute('data-exclude')
+                const matchFieldName = field?.getAttribute('matchFieldName')
+                if (matchFieldName && fieldToExclude === 'true') {
+                  delete data[key]
+                  return
+                }
                 if (dataCast) {
                   data[key] = castValue(value, dataCast as ValueCast) as unknown
                 }

--- a/src/scalars/lib/validators/validateFieldMatch.ts
+++ b/src/scalars/lib/validators/validateFieldMatch.ts
@@ -3,6 +3,7 @@ import type { ValidatorResult } from '../../components/types.js'
 export interface MatchFieldValidationOptions {
   matchFieldName?: string
   errorMessage?: string
+  matchFieldLabelError?: string
 }
 
 /**
@@ -17,14 +18,13 @@ export const validateFieldMatch = (
   formState: Record<string, unknown>,
   options: MatchFieldValidationOptions
 ): ValidatorResult => {
-  const { matchFieldName, errorMessage } = options
+  const { matchFieldName, errorMessage, matchFieldLabelError } = options
 
   if (!matchFieldName) return true
 
   const targetValue = formState[matchFieldName] as string
-
   if (value !== targetValue) {
-    return errorMessage ?? `Field must match the ${matchFieldName} field`
+    return errorMessage ?? `Field must match the ${matchFieldLabelError} label`
   }
 
   return true

--- a/src/scalars/lib/validators/validateFieldMatch.ts
+++ b/src/scalars/lib/validators/validateFieldMatch.ts
@@ -1,0 +1,31 @@
+import type { ValidatorResult } from '../../components/types.js'
+
+export interface MatchFieldValidationOptions {
+  matchFieldName?: string
+  errorMessage?: string
+}
+
+/**
+ * Validates if a field value matches another field in the form
+ * @param value - The current field value
+ * @param formState - The complete form state
+ * @param options - Validation options containing the field name to match and optional error message
+ * @returns true if valid, error message if invalid
+ */
+export const validateFieldMatch = (
+  value: string,
+  formState: Record<string, unknown>,
+  options: MatchFieldValidationOptions
+): ValidatorResult => {
+  const { matchFieldName, errorMessage } = options
+
+  if (!matchFieldName) return true
+
+  const targetValue = formState[matchFieldName] as string
+
+  if (value !== targetValue) {
+    return errorMessage ?? `Field must match the ${matchFieldName} field`
+  }
+
+  return true
+}

--- a/src/scalars/lib/validators/validateFieldMatch.ts
+++ b/src/scalars/lib/validators/validateFieldMatch.ts
@@ -24,7 +24,7 @@ export const validateFieldMatch = (
 
   const targetValue = formState[matchFieldName] as string
   if (value !== targetValue) {
-    return errorMessage ?? `Field must match the ${matchFieldLabelError} label`
+    return errorMessage ?? `Field must match the ${matchFieldLabelError} field`
   }
 
   return true

--- a/src/ui/components/data-entry/email-input/email-input.tsx
+++ b/src/ui/components/data-entry/email-input/email-input.tsx
@@ -58,9 +58,11 @@ const EmailInput = React.forwardRef<HTMLInputElement, EmailInputProps>(
             onChange={handleChange}
             onBlur={onBlur}
             disabled={disabled}
+            data-label={label}
             id={id}
             type="email"
             autoComplete={autoCompleteValue}
+            data-exclude={true}
             required={required}
             ref={ref}
             {...filteredProps}


### PR DESCRIPTION
## Ticket
https://trello.com/c/Hl5iClSo/1078-16-email

## Description
- Allow validate a field base in other field throw the matchFieldName props
- Should ensure that the component can be used inside and outside of the form context.
- Should an email confirmation field be requested if **showEmaildConfirmation** is true.

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
<img width="1717" alt="image" src="https://github.com/user-attachments/assets/e23a384d-b9af-40d9-8896-4224387874a9" />
<img width="1320" alt="image" src="https://github.com/user-attachments/assets/5c044d10-ad61-44cf-94f5-1c3c5d4e72a7" />

