### PR TITLE
fix(scalars): fix submit id in id-field correct-way get id email

### DIFF
--- a/src/scalars/components/email-field/email-field.tsx
+++ b/src/scalars/components/email-field/email-field.tsx
@@ -29,11 +29,12 @@ const EmailField = withFieldValidation<EmailFieldProps>(EmailInput, {
         if (!matchFieldName) return true
         const currentField = document.querySelector(`input[name="${matchFieldName}"]`)
         const form = currentField?.closest('form')
-        const formId = form?.id
+        const formId = form?.getAttribute('id')
 
         const matchFieldSelector = formId
           ? `#${escapeIdForSelector(formId)} input[name="${matchFieldName}"]`
           : `input[name="${matchFieldName}"]`
+
         const matchFieldElement = document.querySelector(matchFieldSelector)
 
         if (!matchFieldElement) return true

--- a/src/scalars/components/id-field/id-field.tsx
+++ b/src/scalars/components/id-field/id-field.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { nanoid } from 'nanoid'
 
@@ -15,25 +15,29 @@ export interface IdFieldProps {
 export const IdField: React.FC<IdFieldProps> = ({ name = 'id', value, generator = 'nanoid', ...rest }) => {
   const {
     register,
+    setValue,
     formState: { submitCount },
   } = useFormContext()
-  const actualValue = useMemo(
-    () => {
-      if (value !== undefined) return value
 
-      if (typeof generator === 'function') return generator()
+  const actualValue = useMemo(() => {
+    if (value !== undefined) return value
 
-      switch (generator) {
-        case 'nanoid':
-          return nanoid()
-        case 'uuid':
-          return crypto.randomUUID()
-      }
-    },
+    if (typeof generator === 'function') return generator()
+
+    switch (generator) {
+      case 'nanoid':
+        return nanoid()
+      case 'uuid':
+        return crypto.randomUUID()
+    }
     // We want to re-generate the ID on every submit
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [value, generator, submitCount]
-  )
+  }, [value, generator, submitCount])
+
+  // Sync the generated ID with react-hook-form when actualValue changes (submitCount)
+  useEffect(() => {
+    setValue(name, actualValue)
+  }, [setValue, name, actualValue])
 
   return <input type="hidden" value={actualValue} {...register(name)} {...rest} />
 }


### PR DESCRIPTION
## Ticket
- https://trello.com/c/Hl5iClSo/1078-16-email

## Description
- Submitting the value several time, only once is reflected (Connect) . Fix the IdField, to generate a new id, in each submit

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
