### PR TITLE
fix(scalars): pass min and max values to field

### DIFF
--- a/src/scalars/components/email-field/email-field.stories.tsx
+++ b/src/scalars/components/email-field/email-field.stories.tsx
@@ -26,6 +26,8 @@ const meta: Meta<typeof EmailField> = {
       },
     }),
     ...PrebuiltArgTypes.pattern,
+    ...PrebuiltArgTypes.minLength,
+    ...PrebuiltArgTypes.maxLength,
     ...PrebuiltArgTypes.viewMode,
     ...PrebuiltArgTypes.baseValue,
     allowedDomains: {
@@ -45,24 +47,6 @@ const meta: Meta<typeof EmailField> = {
         type: { summary: 'string' },
         detail:
           'When provided, this field will validate that its value matches the value of the field with the specified name. Common use case: email confirmation fields.',
-        category: StorybookControlCategory.VALIDATION,
-      },
-    },
-    minLength: {
-      control: 'number',
-      description: 'Minimum length of the email field',
-      table: {
-        type: { summary: 'number' },
-        detail: 'Minimum length of the email field',
-        category: StorybookControlCategory.VALIDATION,
-      },
-    },
-    maxLength: {
-      control: 'number',
-      description: 'Maximum length of the email field',
-      table: {
-        type: { summary: 'number' },
-        detail: 'Maximum length of the email field',
         category: StorybookControlCategory.VALIDATION,
       },
     },

--- a/src/scalars/components/email-field/email-field.stories.tsx
+++ b/src/scalars/components/email-field/email-field.stories.tsx
@@ -25,8 +25,6 @@ const meta: Meta<typeof EmailField> = {
         validators: false,
       },
     }),
-    ...PrebuiltArgTypes.minLength,
-    ...PrebuiltArgTypes.maxLength,
     ...PrebuiltArgTypes.pattern,
     ...PrebuiltArgTypes.viewMode,
     ...PrebuiltArgTypes.baseValue,
@@ -50,9 +48,30 @@ const meta: Meta<typeof EmailField> = {
         category: StorybookControlCategory.VALIDATION,
       },
     },
+    minLength: {
+      control: 'number',
+      description: 'Minimum length of the email field',
+      table: {
+        type: { summary: 'number' },
+        detail: 'Minimum length of the email field',
+        category: StorybookControlCategory.VALIDATION,
+      },
+    },
+    maxLength: {
+      control: 'number',
+      description: 'Maximum length of the email field',
+      table: {
+        type: { summary: 'number' },
+        detail: 'Maximum length of the email field',
+        category: StorybookControlCategory.VALIDATION,
+      },
+    },
   },
   args: {
     name: 'email-field',
+    allowedDomains: [],
+    errors: [],
+    warnings: [],
   },
 }
 

--- a/src/scalars/components/email-field/email-field.stories.tsx
+++ b/src/scalars/components/email-field/email-field.stories.tsx
@@ -53,9 +53,6 @@ const meta: Meta<typeof EmailField> = {
   },
   args: {
     name: 'email-field',
-    allowedDomains: [],
-    errors: [],
-    warnings: [],
   },
 }
 

--- a/src/scalars/components/email-field/email-field.tsx
+++ b/src/scalars/components/email-field/email-field.tsx
@@ -9,6 +9,8 @@ export type EmailFieldProps = Omit<EmailInputProps, 'maxLength' | 'minLength'> &
   FieldErrorHandling & {
     allowedDomains?: string[]
     matchFieldName?: string
+    maxLength?: number
+    minLength?: number
   }
 
 const EmailField = withFieldValidation<EmailFieldProps>(EmailInput, {


### PR DESCRIPTION
## Ticket
https://trello.com/c/Hl5iClSo/1078-16-email


## Description
 The maxLenght and/or minLenght prop set. * After cleaning the prop, the field should no longer validate against the prop value set before. The field validates against the prop value even after it was cleaned.  The props are no correct add to the field

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
