### PR TITLE
Feat/keep row index when sorting

### DIFF
--- a/src/ui/components/object-set-table/examples/table-editing/table-editing.tsx
+++ b/src/ui/components/object-set-table/examples/table-editing/table-editing.tsx
@@ -16,6 +16,14 @@ const TableEditingExample = (props: Omit<ObjectSetTableConfig<MockedPerson>, 'co
         title: 'User',
         editable: true,
         sortable: true,
+        onSort: ({ sortState, data }) => {
+          // This is just for example purposes
+          // eslint-disable-next-line no-console
+          console.log(
+            `----> onSort (${sortState?.direction ?? 'unsorted'})`,
+            data.reduce((acc, curr) => `${acc}${curr.firstName}, `, '')
+          )
+        },
         width: 140,
         onSave: (value: unknown, context: CellContext<MockedPerson>) => {
           setData((prevData) => {

--- a/src/ui/components/object-set-table/logic/table-api.ts
+++ b/src/ui/components/object-set-table/logic/table-api.ts
@@ -193,12 +193,6 @@ class TableApi<TData> implements PrivateTableApiBase<TData> {
    * @param direction - The direction to sort the rows. Null if the sorting should be removed
    */
   sortRows(columnIndex: number, direction: SortDirection | null) {
-    if (direction === null) {
-      this._getState().dispatch?.({
-        type: 'SORT_COLUMN',
-        payload: { columnIndex, direction: 'asc', tableConfig: this._getConfig() },
-      })
-    }
     this._getState().dispatch?.({
       type: 'SORT_COLUMN',
       payload: { columnIndex, direction, tableConfig: this._getConfig() },

--- a/src/ui/components/object-set-table/object-set-table.stories.tsx
+++ b/src/ui/components/object-set-table/object-set-table.stories.tsx
@@ -109,6 +109,7 @@ import TableEditingExample from './examples/table-editing/table-editing.js'
  * |----------|------|---------|-------------|
  * | `sortable` | `boolean` | `false` | Enable column sorting |
  * | `rowComparator` | `(a: unknown, b: unknown, context: SortableColumnContext<T>) => number` | Type-based comparator | Custom sorting logic |
+ * | `onSort` | `(context: SortableColumnContext<T>) => void` | `undefined` | Callback function called when column is sorted |
  *
  * ---
  *

--- a/src/ui/components/object-set-table/types.ts
+++ b/src/ui/components/object-set-table/types.ts
@@ -159,6 +159,20 @@ export type SortFn<T extends DataType = DataType> = (
   context: SortableColumnContext<T>
 ) => number
 
+export type OnSortCallbackFn<T extends DataType = DataType> = (context: SortableColumnContext<T>) => void
+
+export interface SortState {
+  /**
+   * The index of the column that is being sorted.
+   */
+  columnIndex: number
+
+  /**
+   * The direction of the sort.
+   */
+  direction: SortDirection
+}
+
 /**
  * The context for a sortable column.
  *
@@ -179,6 +193,11 @@ export interface SortableColumnContext<T extends DataType> {
    * The data.
    */
   data: T[]
+
+  /**
+   * The sort state.
+   */
+  sortState: SortState | null
 }
 
 /**
@@ -286,6 +305,13 @@ export interface SortableColumnDef<T extends DataType> {
    * }
    */
   rowComparator?: SortFn<T>
+
+  /**
+   * A function that is called when the column is sorted.
+   *
+   * @param context The sort context.
+   */
+  onSort?: OnSortCallbackFn<T>
 }
 
 export interface ColumnDef<T extends DataType = DataType> extends SortableColumnDef<T> {


### PR DESCRIPTION
## Ticket
https://trello.com/c/sh1Cb4qN/915-initialize-table-structure-and-basic-scaffolding

## Description
Added `onSort`, a callback that is invoked everytime a column sort changes

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings
