### PR TITLE
feat(table): move delete options to the secondary row actions

### DIFF
--- a/src/ui/components/dropdown-menu/dropdown-menu.tsx
+++ b/src/ui/components/dropdown-menu/dropdown-menu.tsx
@@ -142,7 +142,7 @@ const DropdownMenuSeparator = ({
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      className={cn('bg-gray-300 -mx-1 my-1 h-px', className)}
       {...props}
     />
   )

--- a/src/ui/components/object-set-table/logic/table-api.ts
+++ b/src/ui/components/object-set-table/logic/table-api.ts
@@ -3,7 +3,7 @@ import type { TableState } from '../subcomponents/table-provider/table-reducer.j
 import type { CellContext, ObjectSetTableConfig, SortDirection } from '../types.js'
 import { getNextSelectedCell } from '../utils.js'
 import { SelectionManager } from './selection-manager.js'
-import type { PrivateTableApiBase, SortingInfo } from './types.js'
+import type { ConfirmationOptions, PrivateTableApiBase, SortingInfo } from './types.js'
 import { confirm } from '../../confirm/index.js'
 
 class TableApi<TData> implements PrivateTableApiBase<TData> {
@@ -117,11 +117,11 @@ class TableApi<TData> implements PrivateTableApiBase<TData> {
     // restore the form value
     const formRef = this._getState().dataFormReferences[row][column]
     const columnDef = this._getConfig().columns[column]
-    if (formRef) {
-      const originalValue = columnDef.valueGetter?.(
-        this._getState().data[row].data,
-        this._createCellContext(row, column)
-      )
+    const stateData = this._getState().data
+    // if stateData[row] is undefined is probably because we're inserting a new row
+    // or because the row is empty, so we don't need to restore the value at all
+    if (formRef && stateData[row]) {
+      const originalValue = columnDef.valueGetter?.(stateData[row]?.data, this._createCellContext(row, column))
       formRef.current?.setValue(columnDef.field, originalValue)
     }
 
@@ -228,20 +228,31 @@ class TableApi<TData> implements PrivateTableApiBase<TData> {
    * Deletes the rows at the given indexes
    *
    * @param rows - The indexes of the rows to delete
+   * @param askConfirmation - Whether to ask for confirmation before deleting the rows
    */
-  async deleteRows(rows: number[]): Promise<void> {
+  async deleteRows(
+    rows: number[],
+    confirmationOptions: ConfirmationOptions = { askConfirmation: true }
+  ): Promise<void> {
     if (!this.canDelete()) return
 
-    const rowsData = rows.map((row) => this._getState().data[row].data)
-    const count = rows.length
-    const confirmed = await confirm({
-      title: 'Delete entries',
-      description: `Are you sure you want to delete ${count} selected ${count === 1 ? 'entry' : 'entries'}?`,
-      confirmLabel: 'Continue',
-      confirmVariant: 'default',
-      cancelLabel: 'Cancel',
-      cancelVariant: 'secondary',
-    })
+    const actualRows = rows.filter((rowIndex) => rowIndex < this._getState().data.length)
+    const rowsData = actualRows.map((row) => this._getState().data[row].data)
+
+    let confirmed = true
+    if (confirmationOptions.askConfirmation) {
+      const count = actualRows.length
+      confirmed = await confirm({
+        title: confirmationOptions.title ?? 'Delete entries',
+        description:
+          confirmationOptions.description ??
+          `Are you sure you want to delete ${count} selected ${count === 1 ? 'entry' : 'entries'}?`,
+        confirmLabel: 'Continue',
+        confirmVariant: 'default',
+        cancelLabel: 'Cancel',
+        cancelVariant: 'secondary',
+      })
+    }
 
     if (confirmed) {
       await this._getConfig().onDelete?.(rowsData)

--- a/src/ui/components/object-set-table/logic/table-api.ts
+++ b/src/ui/components/object-set-table/logic/table-api.ts
@@ -228,7 +228,16 @@ class TableApi<TData> implements PrivateTableApiBase<TData> {
    * Deletes the rows at the given indexes
    *
    * @param rows - The indexes of the rows to delete
-   * @param askConfirmation - Whether to ask for confirmation before deleting the rows
+   * @param confirmationOptions - The confirmation options. If `askConfirmation` is `true`, the confirmation dialog will be shown.
+   *
+   * @example
+   * ```tsx
+   * api.deleteRows([1, 2], {
+   *   askConfirmation: true,
+   *   title: 'Delete Accounts',
+   *   description: 'Are you sure you want to delete 2 accounts?',
+   * })
+   * ```
    */
   async deleteRows(
     rows: number[],

--- a/src/ui/components/object-set-table/logic/types.ts
+++ b/src/ui/components/object-set-table/logic/types.ts
@@ -6,6 +6,12 @@ export interface SortingInfo {
   direction: SortDirection
 }
 
+export interface ConfirmationOptions {
+  askConfirmation?: boolean
+  title?: string
+  description?: string
+}
+
 export interface TableSelectionManager {
   canSelectRows(): boolean
   canSelectCells(): boolean
@@ -43,7 +49,7 @@ export interface TableApiBase {
 
   // deletion
   canDelete(): boolean
-  deleteRows(rows: number[]): Promise<void>
+  deleteRows(rows: number[], confirmationOptions?: ConfirmationOptions): Promise<void>
 
   // insertion
   canAdd(): boolean

--- a/src/ui/components/object-set-table/subcomponents/cells/information-cell.tsx
+++ b/src/ui/components/object-set-table/subcomponents/cells/information-cell.tsx
@@ -1,34 +1,7 @@
-import { Icon } from '../../../icon/icon.js'
-import { useInternalTableState } from '../table-provider/table-provider.js'
 import { TableCellBasic } from './basic-cell.js'
 
-interface InformationCellProps {
-  rowIndex: number
-  emptyRow?: boolean
-}
-
-const InformationCell = ({ rowIndex, emptyRow }: InformationCellProps) => {
-  const {
-    state: { selectedRowIndexes },
-    api,
-  } = useInternalTableState()
-
-  const canDelete = api.canDelete()
-
-  return (
-    <TableCellBasic className="min-w-[40px] max-w-[40px]">
-      {!emptyRow && canDelete && selectedRowIndexes.includes(rowIndex) && (
-        <div
-          className="flex flex-1 w-full items-center justify-center cursor-pointer text-red-900"
-          onClick={() => {
-            void api.deleteRows([rowIndex])
-          }}
-        >
-          <Icon name="Trash" size={16} />
-        </div>
-      )}
-    </TableCellBasic>
-  )
+const InformationCell = () => {
+  return <TableCellBasic className="min-w-[40px] max-w-[40px]" />
 }
 
 export { InformationCell }

--- a/src/ui/components/object-set-table/subcomponents/rows/render-row.tsx
+++ b/src/ui/components/object-set-table/subcomponents/rows/render-row.tsx
@@ -76,6 +76,7 @@ const RenderRow = <T extends DataType>({ item, rowIndex, mode = 'default' }: Ren
   const rowRef = useRef<HTMLTableRowElement>(null)
 
   // actions state management
+  const canShowActions = mode === 'default' && !!config.onDelete
   const [actionsOpen, setActionsOpen] = useState(false)
   const [isSecondaryActionsOpen, setIsSecondaryActionsOpen] = useState(false)
   const handleRowMouseEnter = useCallback(() => {
@@ -121,16 +122,16 @@ const RenderRow = <T extends DataType>({ item, rowIndex, mode = 'default' }: Ren
         )
       })}
 
-      {(api.isEditable() || api.canDelete()) && <InformationCell rowIndex={rowIndex} emptyRow={mode === 'empty'} />}
+      {(api.isEditable() || api.canDelete()) && <InformationCell />}
 
-      {config.actions && mode === 'default' && (
+      {canShowActions && (
         <RowActions
-          row={item.data}
+          data={item}
           open={actionsOpen}
           rowIndex={rowIndex}
           rowRef={rowRef}
-          primaryAction={config.actions.primary}
-          secondaryActions={config.actions.secondary}
+          primaryAction={config.actions?.primary}
+          secondaryActions={config.actions?.secondary}
           isSecondaryActionsOpen={isSecondaryActionsOpen}
           handleSecondaryActionsOpen={handleSecondaryActionsOpen}
           handleSecondaryActionsClose={handleSecondaryActionsClose}


### PR DESCRIPTION
## Ticket
https://trello.com/c/aWCV973N/1037-apply-deletion-functionality-to-the-objectsettable

## Description
- Remove the delete icon in the information column when the rows are hovered
- Add a "Delete" secondary action if the table allows deletions
- Add a "Delete x selected rows" secondary actions when there are multiple rows selected, allowing to delete all selected rows at once
- Fix insertions
- Add configurable options to the delete function in the table API

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
<img width="677" height="464" alt="Screenshot 2025-07-15 at 8 38 00 PM" src="https://github.com/user-attachments/assets/ec45fa29-dadc-496d-90ca-85550ce96021" />
