### PR TITLE
fix(altas): add placeholder for document without number and name

### DIFF
--- a/src/ui/components/sidebar/sidebar.test.tsx
+++ b/src/ui/components/sidebar/sidebar.test.tsx
@@ -1,8 +1,9 @@
-import { Icon } from '../../components/icon/index.js'
-import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
+import { act, render, screen, waitFor } from '@testing-library/react'
+
+import { Icon } from '../../components/icon/index.js'
 import { Sidebar } from './sidebar.js'
-import { SidebarProvider } from './subcomponents/sidebar-provider/index.js'
+import { SidebarProvider, useSidebar } from './subcomponents/sidebar-provider/index.js'
 
 const mockNodes = [
   {
@@ -19,6 +20,20 @@ const mockNodes = [
   {
     id: '2',
     title: 'Node 2',
+    children: [],
+  },
+]
+
+const mockNodesWithClassName = [
+  {
+    id: '1',
+    title: 'Node with custom class',
+    className: 'custom-node-class text-blue-500',
+    children: [],
+  },
+  {
+    id: '2',
+    title: 'Normal node',
     children: [],
   },
 ]
@@ -76,5 +91,30 @@ describe('Sidebar Component', () => {
 
     // Initially pinning area should not be visible
     expect(screen.queryByTestId('pinning-area')).not.toBeInTheDocument()
+  })
+
+  it('should apply className when node is pinned via user interaction', async () => {
+    let sidebarContext: ReturnType<typeof useSidebar> | null = null
+
+    const TestComponent = () => {
+      sidebarContext = useSidebar()
+      return <Sidebar allowPinning={true} />
+    }
+
+    render(
+      <SidebarProvider nodes={mockNodesWithClassName}>
+        <TestComponent />
+      </SidebarProvider>
+    )
+
+    act(() => {
+      sidebarContext?.togglePin('1')
+    })
+
+    await waitFor(() => {
+      const pinnedNode = screen.getByText('Node with custom class')
+      expect(pinnedNode).toBeInTheDocument()
+      expect(pinnedNode).toHaveClass('custom-node-class', 'text-blue-500')
+    })
   })
 })

--- a/src/ui/components/sidebar/subcomponents/sidebar-item.tsx
+++ b/src/ui/components/sidebar/subcomponents/sidebar-item.tsx
@@ -159,6 +159,7 @@ export const SidebarItem = ({
                 searchTerm={searchTerm}
                 isSearchActive={isSearchActive}
                 pinnedMode={pinnedMode}
+                className={node.className}
               />
 
               {allowPinning && (
@@ -204,18 +205,21 @@ const RenderTitle = forwardRef<
     searchTerm: string
     isSearchActive: boolean
     pinnedMode: boolean
+    className?: string
   }
->(({ title, searchTerm, isSearchActive, pinnedMode }, ref) => {
+>(({ title, searchTerm, isSearchActive, pinnedMode, className }, ref) => {
   return (
-    <div ref={ref} className="truncate text-sm leading-5">
+    <div ref={ref} className={cn('truncate text-sm leading-5', className)}>
       {title.toLowerCase().includes(searchTerm.toLowerCase()) && !pinnedMode ? (
         <span
           dangerouslySetInnerHTML={{
-            __html: title.replace(
-              new RegExp(searchTerm, 'gi'),
-              (match) =>
-                `<span class="${isSearchActive ? 'bg-yellow-300 dark:bg-[#604B00]' : 'bg-gray-300 dark:bg-charcoal-800'}">${match}</span>`
-            ),
+            __html: title.replace(new RegExp(searchTerm, 'gi'), (match) => {
+              const baseClasses = isSearchActive
+                ? 'bg-yellow-300 dark:bg-[#604B00]'
+                : 'bg-gray-300 dark:bg-charcoal-800'
+              const combinedClasses = className ? `${baseClasses} ${className}` : baseClasses
+              return `<span class="${combinedClasses}">${match}</span>`
+            }),
           }}
         />
       ) : (

--- a/src/ui/components/sidebar/types.ts
+++ b/src/ui/components/sidebar/types.ts
@@ -18,6 +18,7 @@ export interface SidebarNode {
   icon?: SidebarIcon
   expandedIcon?: SidebarIcon
   status?: NodeStatus
+  className?: string
 }
 
 export interface FlattenedNode extends SidebarNode {


### PR DESCRIPTION
## Ticket
https://trello.com/c/8TO462mo/1112-document-types-created-are-represented-with


## Description
- Should ensure that the node is by default created with the placeholder: Doc No - Name

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
<img width="1201" height="881" alt="prove" src="https://github.com/user-attachments/assets/f4d185a8-1d87-483b-87f6-4187ce0c5972" />

