### PR TITLE
feat(ui): add color transition when a password suggestion is met

### DIFF
--- a/src/ui/components/data-entry/password-input/password-strength.tsx
+++ b/src/ui/components/data-entry/password-input/password-strength.tsx
@@ -4,8 +4,14 @@ import * as zxcvbnCommonPackage from '@zxcvbn-ts/language-common'
 import * as zxcvbnEnPackage from '@zxcvbn-ts/language-en'
 import { cn } from '../../../../scalars/lib/index.js'
 import { ProgressBar } from '../../../../scalars/components/fragments/progress-bar/index.js'
-import { FormMessageList } from '../../../../scalars/components/fragments/form-message/index.js'
-import { adjustStrengthScore, specialCharacters, strengthColors, strengthLabels, strengthValues } from './utils.js'
+import { FormMessage } from '../../../../scalars/components/fragments/form-message/index.js'
+import {
+  adjustStrengthScore,
+  getPasswordRequirements,
+  strengthColors,
+  strengthLabels,
+  strengthValues,
+} from './utils.js'
 
 const options = {
   dictionary: {
@@ -50,6 +56,7 @@ const PasswordStrength = ({ password }: { password: string }) => {
 
   const score = adjustStrengthScore(password, result?.score)
   const showWeak = password === '' || (score === undefined && wasEmpty)
+  const requirements = getPasswordRequirements(password)
 
   return (
     <div className={cn('w-full flex flex-col gap-4 px-4 pt-2 pb-4 rounded-md')}>
@@ -76,16 +83,23 @@ const PasswordStrength = ({ password }: { password: string }) => {
 
       <div className={cn('w-full flex flex-col gap-4')}>
         <h4 className={cn('text-sm leading-[18px] font-medium text-gray-500')}>Suggestions</h4>
-        <FormMessageList
-          messages={[
-            'Minimum 8 characters',
-            'At least one uppercase letter',
-            'At least one lowercase letter',
-            'At least one number',
-            `At least one special character: ${specialCharacters}`,
-          ]}
-          className={cn('gap-2 [&>li]:text-gray-500 [&>li]:before:bg-gray-500')}
-        />
+        <ul className={cn('flex flex-col gap-2')}>
+          {requirements.map((requirement) => (
+            <FormMessage
+              key={requirement.text}
+              as="li"
+              className={cn(
+                'relative pl-4',
+                'before:absolute before:left-0 before:top-[0.4em] before:size-2 before:rounded-full',
+                'transition-colors duration-200 ease-in-out',
+                'before:transition-colors before:duration-200 before:ease-in-out',
+                requirement.isValid ? 'text-green-900 before:bg-green-900' : 'text-gray-500 before:bg-gray-500'
+              )}
+            >
+              {requirement.text}
+            </FormMessage>
+          ))}
+        </ul>
       </div>
     </div>
   )

--- a/src/ui/components/data-entry/password-input/utils.ts
+++ b/src/ui/components/data-entry/password-input/utils.ts
@@ -10,20 +10,39 @@ export const strengthColors = [
 export const strengthLabels = ['Weak', 'Weak', 'Weak', 'Medium', 'Strong']
 export const strengthValues = [33, 33, 33, 66, 100]
 
-const validatePasswordSuggestions = (password: string): boolean => {
-  if (password.length < 8) return false
+const validateMinLength = (password: string): boolean => {
+  return password.length >= 8
+}
 
-  if (!/[A-Z]/.test(password)) return false
-  if (!/[a-z]/.test(password)) return false
-  if (!/[0-9]/.test(password)) return false
+const validateUppercase = (password: string): boolean => {
+  return /[A-Z]/.test(password)
+}
 
+const validateLowercase = (password: string): boolean => {
+  return /[a-z]/.test(password)
+}
+
+const validateNumber = (password: string): boolean => {
+  return /[0-9]/.test(password)
+}
+
+const validateSpecialCharacter = (password: string): boolean => {
   for (const char of specialCharacters) {
     if (password.includes(char)) {
       return true
     }
   }
-
   return false
+}
+
+const validatePasswordSuggestions = (password: string): boolean => {
+  return (
+    validateMinLength(password) &&
+    validateUppercase(password) &&
+    validateLowercase(password) &&
+    validateNumber(password) &&
+    validateSpecialCharacter(password)
+  )
 }
 
 export const adjustStrengthScore = (password: string, score: number | undefined): number | undefined => {
@@ -31,4 +50,29 @@ export const adjustStrengthScore = (password: string, score: number | undefined)
     return 3
   }
   return score
+}
+
+export const getPasswordRequirements = (password: string) => {
+  return [
+    {
+      text: 'Minimum 8 characters',
+      isValid: validateMinLength(password),
+    },
+    {
+      text: 'At least one uppercase letter',
+      isValid: validateUppercase(password),
+    },
+    {
+      text: 'At least one lowercase letter',
+      isValid: validateLowercase(password),
+    },
+    {
+      text: 'At least one number',
+      isValid: validateNumber(password),
+    },
+    {
+      text: `At least one special character: ${specialCharacters}`,
+      isValid: validateSpecialCharacter(password),
+    },
+  ]
 }


### PR DESCRIPTION
## Ticket
https://trello.com/c/vaeTU0JQ/1124-indicate-when-password-requirements-are-met-within-the-password-component

## Description
- Adds a color transition when a password suggestion is met

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
<img width="1920" height="1020" alt="password" src="https://github.com/user-attachments/assets/0bfd402a-03c5-4a2c-9289-7ee1e868da37" />