### PR TITLE
fix(scalars): avoid warning caused by using both value and defaultValue

### DIFF
--- a/src/ui/components/data-entry/number-input/number-input.test.tsx
+++ b/src/ui/components/data-entry/number-input/number-input.test.tsx
@@ -278,4 +278,35 @@ describe('NumberInput', () => {
       expect(screen.getByText('454')).toBeInTheDocument()
     })
   })
+
+  describe('Controlled and Uncontrolled Input Behavior', () => {
+    it('should display empty input when no value is provided', () => {
+      render(<NumberInput label="Test Label" name="Label" onChange={mockOnChange} />)
+
+      const input = screen.getByRole('spinbutton')
+      expect(input).toHaveValue('')
+    })
+
+    it('should display defaultValue when value is undefined', () => {
+      render(<NumberInput label="Test Label" name="Label" defaultValue={100} onChange={mockOnChange} />)
+
+      const input = screen.getByRole('spinbutton')
+      expect(input).toHaveValue('100')
+    })
+
+    it('should handle dynamic value changes without warnings', () => {
+      const { rerender } = render(<NumberInput label="Test Label" name="Label" onChange={mockOnChange} />)
+
+      const input = screen.getByRole('spinbutton')
+      expect(input).toHaveValue('')
+
+      // Simulate value being set dynamically
+      rerender(<NumberInput label="Test Label" name="Label" value={25} onChange={mockOnChange} />)
+      expect(input).toHaveValue('25')
+
+      // Simulate value being cleared
+      rerender(<NumberInput label="Test Label" name="Label" onChange={mockOnChange} />)
+      expect(input).toHaveValue('')
+    })
+  })
 })

--- a/src/ui/components/data-entry/number-input/number-input.test.tsx
+++ b/src/ui/components/data-entry/number-input/number-input.test.tsx
@@ -294,17 +294,15 @@ describe('NumberInput', () => {
       expect(input).toHaveValue('100')
     })
 
-    it('should handle dynamic value changes without warnings', () => {
+    it('should switch between controlled and uncontrolled modes without warnings', () => {
       const { rerender } = render(<NumberInput label="Test Label" name="Label" onChange={mockOnChange} />)
 
       const input = screen.getByRole('spinbutton')
       expect(input).toHaveValue('')
 
-      // Simulate value being set dynamically
       rerender(<NumberInput label="Test Label" name="Label" value={25} onChange={mockOnChange} />)
       expect(input).toHaveValue('25')
 
-      // Simulate value being cleared
       rerender(<NumberInput label="Test Label" name="Label" onChange={mockOnChange} />)
       expect(input).toHaveValue('')
     })

--- a/src/ui/components/data-entry/number-input/number-input.tsx
+++ b/src/ui/components/data-entry/number-input/number-input.tsx
@@ -98,9 +98,9 @@ const NumberInputRaw = forwardRef<HTMLInputElement, InputNumberPropsWithDifferen
                 preventLetterInput(e)
                 preventInvalidCharsAndHandleArrows(e)
               }}
-              value={value === undefined ? '' : value.toString()}
+              value={value !== undefined ? value.toString() : ''}
               onBlur={handleBlur}
-              defaultValue={defaultValue?.toString()}
+              defaultValue={value === undefined && defaultValue !== undefined ? defaultValue.toString() : undefined}
               onChange={onChange}
               onPaste={blockInvalidPaste}
               ref={ref}
@@ -182,7 +182,7 @@ const NumberInputUncontroller = forwardRef<HTMLInputElement, InputNumberPropsWit
     const newValue = e.target.value
     setValue(newValue as unknown as number)
   }
-  return <NumberInputRaw {...props} value={value} onChange={handleChange} defaultValue={value} ref={ref} />
+  return <NumberInputRaw {...props} value={value} onChange={handleChange} ref={ref} />
 })
 NumberInputUncontroller.displayName = 'NumberInputUncontroller'
 

--- a/src/ui/components/data-entry/number-input/number-input.tsx
+++ b/src/ui/components/data-entry/number-input/number-input.tsx
@@ -11,6 +11,7 @@ import { cn } from '../../../../scalars/lib/index.js'
 import { Input } from '../input/index.js'
 import TextInputDiff from '../text-input/text-input-diff.js'
 import type { WithDifference } from '../../../../scalars/components/types.js'
+import { de } from 'date-fns/locale'
 
 type InputNumberPropsWithDifference = InputNumberProps & WithDifference<string | number | bigint>
 
@@ -65,7 +66,10 @@ const NumberInputRaw = forwardRef<HTMLInputElement, InputNumberPropsWithDifferen
       trailingZeros,
       precision,
     })
-
+console.log({
+  value,
+  defaultValue,
+})
     if (viewMode === 'edition') {
       return (
         <FormGroup>
@@ -98,9 +102,8 @@ const NumberInputRaw = forwardRef<HTMLInputElement, InputNumberPropsWithDifferen
                 preventLetterInput(e)
                 preventInvalidCharsAndHandleArrows(e)
               }}
-              value={value !== undefined ? value.toString() : ''}
+              value={value !== undefined ? value.toString() : defaultValue !== undefined ? defaultValue.toString() : ''}
               onBlur={handleBlur}
-              defaultValue={value === undefined && defaultValue !== undefined ? defaultValue.toString() : undefined}
               onChange={onChange}
               onPaste={blockInvalidPaste}
               ref={ref}

--- a/src/ui/components/data-entry/number-input/number-input.tsx
+++ b/src/ui/components/data-entry/number-input/number-input.tsx
@@ -11,7 +11,6 @@ import { cn } from '../../../../scalars/lib/index.js'
 import { Input } from '../input/index.js'
 import TextInputDiff from '../text-input/text-input-diff.js'
 import type { WithDifference } from '../../../../scalars/components/types.js'
-import { de } from 'date-fns/locale'
 
 type InputNumberPropsWithDifference = InputNumberProps & WithDifference<string | number | bigint>
 
@@ -66,10 +65,7 @@ const NumberInputRaw = forwardRef<HTMLInputElement, InputNumberPropsWithDifferen
       trailingZeros,
       precision,
     })
-console.log({
-  value,
-  defaultValue,
-})
+
     if (viewMode === 'edition') {
       return (
         <FormGroup>


### PR DESCRIPTION
## Ticket
https://trello.com/c/PDs76XV9/1151-internal-error-when-the-value-default-value-is-defined-in-the-number-input

## Description
- Should ensure that the component doesn't trigger any error when the values are defined.

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
