### PR TITLE
fix(scalars): fix the units error

### DIFF
--- a/src/ui/components/data-entry/amount-input/amount-input.test.tsx
+++ b/src/ui/components/data-entry/amount-input/amount-input.test.tsx
@@ -172,4 +172,19 @@ describe('AmountField Component', () => {
       expect(screen.queryByTestId('amount-input-diff')).not.toBeInTheDocument()
     })
   })
+  it('should handle not passing units', () => {
+    render(
+      <AmountInput
+        label="Amount Label"
+        name="amount"
+        type="AmountCurrency"
+        value={{
+          value: '345',
+          unit: 'USD',
+        }}
+      />
+    )
+    expect(screen.getByLabelText('Amount Label')).toBeInTheDocument()
+    expect(screen.getByText('345')).toBeInTheDocument()
+  })
 })

--- a/src/ui/components/data-entry/amount-input/amount-input.test.tsx
+++ b/src/ui/components/data-entry/amount-input/amount-input.test.tsx
@@ -185,6 +185,7 @@ describe('AmountField Component', () => {
       />
     )
     expect(screen.getByLabelText('Amount Label')).toBeInTheDocument()
-    expect(screen.getByText('345')).toBeInTheDocument()
+    const input = screen.getByRole('spinbutton')
+    expect(input).toHaveValue('345')
   })
 })

--- a/src/ui/components/data-entry/amount-input/use-amount-input.tsx
+++ b/src/ui/components/data-entry/amount-input/use-amount-input.tsx
@@ -37,6 +37,7 @@ export const useAmountInput = ({
   units,
 }: UseAmountInputProps) => {
   const currentValue = value ?? defaultValue
+  const unitsArray = Array.isArray(units) ? units : []
 
   const baseValue = useMemo(() => {
     if (currentValue === undefined) {
@@ -148,7 +149,7 @@ export const useAmountInput = ({
   const isAmountWithoutUnit = type === 'Amount' && !isAmountWithUnit
 
   const isShowSelect =
-    (isAmountWithUnit && units && units.length > 0) ||
+    (isAmountWithUnit && unitsArray.length > 0) ||
     type === 'AmountFiat' ||
     type === 'AmountCrypto' ||
     type === 'AmountCurrency'
@@ -403,7 +404,7 @@ export const useAmountInput = ({
   const handleIsInputFocused = () => {
     setInputFocused(true)
   }
-  const options = units ?? getDefaultUnits(type)
+  const options = unitsArray.length > 0 ? unitsArray : getDefaultUnits(type)
   // Put the placeholder in case that value its not in the options
   const validatedValueSelect = valueSelect && options.some((unit) => unit.ticker === valueSelect) ? valueSelect : ''
   return {


### PR DESCRIPTION
## Ticket
- https://trello.com/c/iV03PjGR/757-9-amountfield

## Description
-  After interacting with the "units" field (which was previously inactive), a TypeError: options. Some is not a function error occurs. The AmountCurrency (or other amount) component fails to render properly. **Steps to reproduce:** 1. Open amy amount (e.g. AmountCurrency) component in Storybook 2. Activate the "units" field 3. Error appears immediately after interaction.

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
