### PR TITLE
Feat/add max row count

### DIFF
--- a/src/table/components/rows/render-row.tsx
+++ b/src/table/components/rows/render-row.tsx
@@ -83,7 +83,7 @@ const RenderRow = <T extends DataType>({ item, rowIndex, mode = 'default' }: Ren
     }
     return (
       mode === 'default' &&
-      (!!config.onDelete ||
+      (!!api.canDelete() ||
         config.actions?.primary ||
         (Array.isArray(config.actions?.secondary) && config.actions.secondary.length > 0))
     )
@@ -92,7 +92,7 @@ const RenderRow = <T extends DataType>({ item, rowIndex, mode = 'default' }: Ren
     rowIndex,
     selectedRowErrors,
     mode,
-    config.onDelete,
+    api,
     config.actions?.primary,
     config.actions?.secondary,
   ])

--- a/src/table/components/rows/row-actions.tsx
+++ b/src/table/components/rows/row-actions.tsx
@@ -53,6 +53,10 @@ const RowActions = <T extends DataType>({
   }, [config, primaryAction, data, rowIndex])
 
   const deleteActions: Array<RowAction<T>> = useMemo(() => {
+    if (!api.canDelete()) {
+      return []
+    }
+
     return [
       {
         label: 'Delete',
@@ -65,13 +69,13 @@ const RowActions = <T extends DataType>({
       ...(state.selectedRowIndexes.length > 1 && state.selectedRowIndexes.includes(rowIndex)
         ? ([
             {
-              label: `Delete ${Math.min(state.selectedRowIndexes.length, state.defaultData.length)} selected rows`,
+              label: `Delete ${Math.min(state.selectedRowIndexes.length, state.data.length)} selected rows`,
               callback: async (_context) => api.deleteRows(state.selectedRowIndexes),
             },
           ] satisfies Array<RowAction<T>>)
         : []),
     ]
-  }, [api, data.__index, rowIndex, state.defaultData.length, state.selectedRowIndexes])
+  }, [api, data.__index, rowIndex, state.data.length, state.selectedRowIndexes])
 
   const hasSecondaryActions = !!secondaryActions || deleteActions.length > 0
   const haveOnlyOneAction = (!!primaryAction && !hasSecondaryActions) || (hasSecondaryActions && !primaryAction)

--- a/src/table/components/table-provider/table-provider.tsx
+++ b/src/table/components/table-provider/table-provider.tsx
@@ -56,10 +56,9 @@ const TableProvider = <T extends DataType = DataType>({ children, config, tableR
 
   const stateRef = useRef(state)
   const configRef = useRef(config)
-  useEffect(() => {
-    stateRef.current = state
-    configRef.current = config
-  }, [state, config])
+
+  stateRef.current = state
+  configRef.current = config
 
   const [api, publicApi] = useMemo(() => {
     const internalApi = new TableApi<T>(tableRef, configRef, stateRef)

--- a/src/table/docs/adding.mdx
+++ b/src/table/docs/adding.mdx
@@ -6,10 +6,13 @@ import { Meta, Source, Canvas, Controls } from '@storybook/blocks'
 
 Enable row creation in `ObjectSetTable` by providing the `onAdd` prop. When present, an insertion row appears at the bottom. Users type into editable cells in that row; saving a cell calls `onAdd` with a partial payload for the last edited field.
 
+Row addition is automatically disabled when the table reaches the `maxRowCount` limit, ensuring controlled table size management.
+
 ## Requirements
 
 - At least one column must be editable. See [Column Definition → Editing](?path=/docs/data-display-object-set-table-docs-column-definition--readme#editing).
 - Provide an `onAdd` handler. Without it, the insertion row is hidden.
+- Optional: Set `maxRowCount` to limit the maximum number of rows that can be added.
 
 ## Quick start
 
@@ -29,6 +32,7 @@ const [data, setData] = useState<Person[]>([])
 <ObjectSetTable<Person>
   data={data}
   columns={columns}
+  maxRowCount={10} // Limit table to 10 rows maximum
   onAdd={(partial) => {
     // partial only includes the last saved field from the insertion row
     const defaults: Person = { firstName: '', email: '' }
@@ -41,6 +45,7 @@ const [data, setData] = useState<Person[]>([])
 
 - The insertion row is rendered only when `onAdd` is provided.
 - It appears after the last data row and counts toward `minRowCount`. See [Rows → Row Height and Count](?path=/docs/data-display-object-set-table-docs-rows--readme#row-height-and-count).
+- **Row count limits**: The insertion row is automatically hidden when `data.length >= maxRowCount`, preventing users from adding more rows.
 - Saving a cell in the insertion row triggers validation and then calls `onAdd` with `{ [field]: value }` for that cell.
 - The handler may be async; returning a promise is supported.
 - Each save in the insertion row invokes `onAdd`. Commonly, you create the new item on the first save and merge subsequent fields as needed.
@@ -65,6 +70,25 @@ onAdd={async (partial) => {
   setData((prev) => [...prev, created])
 }}
 ```
+
+### Limit table size with maxRowCount
+
+```tsx
+<ObjectSetTable<Person>
+  data={data}
+  columns={columns}
+  maxRowCount={100} // Prevent adding beyond 100 rows
+  onAdd={(partial) => {
+    const newRow: Person = { firstName: '', email: '', ...(partial as Partial<Person>) }
+    setData((prev) => [...prev, newRow])
+  }}
+/>
+```
+
+When `maxRowCount` is reached:
+- The insertion row is automatically hidden
+- Users cannot add more rows until some are deleted
+- The `canAdd()` API method returns `false`
 
 For editing interactions (enter/commit/cancel, validation), see [Editing](?path=/docs/data-display-object-set-table-docs-editing--readme).
 

--- a/src/table/docs/api.mdx
+++ b/src/table/docs/api.mdx
@@ -101,7 +101,7 @@ if (selected.length) {
 
 For how the insertion row behaves and how to wire `onAdd`, see [Adding Rows](?path=/docs/data-display-object-set-table-docs-adding--readme).
 
-- `canAdd(): boolean`: True when the table was configured with `onAdd`.
+- `canAdd(): boolean`: True when the table was configured with `onAdd` **and** the current data length is less than `maxRowCount`. Returns `false` when the maximum row limit is reached.
 - `isAdding(): boolean`: True while the user is editing the insertion row (the special last row). Useful to detect add context during editing.
 
 Example:
@@ -110,6 +110,9 @@ Example:
 if (apiRef.current?.canAdd()) {
   const adding = apiRef.current?.isAdding()
   // e.g. show a small hint while the insertion row is being edited
+} else {
+  // Insertion row is hidden - either no onAdd handler or maxRowCount reached
+  console.log('Cannot add more rows - check onAdd handler and maxRowCount limit')
 }
 ```
 

--- a/src/table/docs/rows.mdx
+++ b/src/table/docs/rows.mdx
@@ -8,14 +8,15 @@ This page covers row-related behavior and configuration for `ObjectSetTable`.
 
 ## Row properties
 
-| Property            | Type                                                       | Default  | Description                                                                          |
-| ------------------- | ---------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------ |
-| `allowRowSelection` | `boolean`                                                  | `true`   | Enables row selection via mouse and keyboard.                                        |
-| `showRowNumbers`    | `boolean`                                                  | `true`   | Shows a leading column with row numbers; also acts as a selection target.            |
-| `minRowCount`       | `number`                                                   | `0`      | Ensures the table renders at least this many rows by adding empty placeholder rows.  |
-| `minRowHeight`      | `number \| 'auto'`                                         | `'auto'` | Minimum pixel height for each row; affects all cells, including the row number cell. |
-| `onAdd`             | `(data: Record<string, unknown>) => Promise<void> \| void` | —        | Enables an insertion row at the bottom for adding items.                             |
-| `onDelete`          | `(rows: T[]) => Promise<void> \| void`                     | —        | Enables deletion UI and keyboard deletion of selected rows.                          |
+| Property            | Type                                                       | Default    | Description                                                                          |
+| ------------------- | ---------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------ |
+| `allowRowSelection` | `boolean`                                                  | `true`     | Enables row selection via mouse and keyboard.                                        |
+| `showRowNumbers`    | `boolean`                                                  | `true`     | Shows a leading column with row numbers; also acts as a selection target.            |
+| `minRowCount`       | `number`                                                   | `0`        | Ensures the table renders at least this many rows by adding empty placeholder rows.  |
+| `maxRowCount`       | `number`                                                   | `Infinity` | Limits the maximum number of rows. When reached, prevents adding new rows.           |
+| `minRowHeight`      | `number \| 'auto'`                                         | `'auto'`   | Minimum pixel height for each row; affects all cells, including the row number cell. |
+| `onAdd`             | `(data: Record<string, unknown>) => Promise<void> \| void` | —          | Enables an insertion row at the bottom for adding items.                             |
+| `onDelete`          | `(rows: T[]) => Promise<void> \| void`                     | —          | Enables deletion UI and keyboard deletion of selected rows.                          |
 
 For column-level editing controls, see the Column Definition doc and the Editing doc:
 
@@ -58,7 +59,7 @@ Notes:
 
 ## Row Height and Count
 
-Control table density and visual stability:
+Control table density, visual stability, and size limits:
 
 ```tsx
 <ObjectSetTable
@@ -66,13 +67,16 @@ Control table density and visual stability:
   columns={columns}
   minRowHeight={40} // pixels; 'auto' uses content height
   minRowCount={10} // renders empty placeholder rows up to this count
+  maxRowCount={50} // limits maximum rows; disables adding when reached
 />
 ```
 
 Behavior details:
 
-- Empty rows are rendered to satisfy `minRowCount`. They are non-interactive placeholders.
+- **minRowCount**: Empty rows are rendered to satisfy the minimum. They are non-interactive placeholders.
+- **maxRowCount**: When the data length reaches this limit, the add functionality is automatically disabled.
 - If `onAdd` is provided (insertion row enabled), that insertion row counts toward `minRowCount`.
+- Row count limits work together: deletion is prevented below `minRowCount`, addition is prevented above `maxRowCount`.
 
 ---
 

--- a/src/table/examples/table-editing/table-editing.tsx
+++ b/src/table/examples/table-editing/table-editing.tsx
@@ -193,18 +193,20 @@ const TableEditingExample = (props: Omit<ObjectSetTableConfig<MockedPerson>, 'co
       columns={columns}
       data={data}
       minRowCount={10}
+      maxRowCount={15}
       actions={actions}
       {...props}
       onDelete={(rows) => {
         setData((prevData) => {
           const newData = [...prevData]
-          const filteredData = newData.filter((row) => !rows.some((person) => person.email === row.email))
+          const filteredData = newData.filter((row) => !rows.some((person) => person.id === row.id))
 
           return filteredData
         })
       }}
       onAdd={(data) => {
         const newPerson: MockedPerson = {
+          id: crypto.randomUUID(),
           firstName: '',
           status: 'inactive',
           payment: 0,

--- a/src/table/table/mock-data.ts
+++ b/src/table/table/mock-data.ts
@@ -1,4 +1,5 @@
 export interface MockedPerson {
+  id: string
   firstName: string | null
   walletAddress: string
   isActive: boolean
@@ -16,6 +17,7 @@ export interface MockedPerson {
 
 export const mockData: MockedPerson[] = [
   {
+    id: '1',
     firstName: 'Alice',
     walletAddress: '0x1234567890abcdef',
     isActive: true,
@@ -31,6 +33,7 @@ export const mockData: MockedPerson[] = [
     },
   },
   {
+    id: '2',
     firstName: 'Bob',
     walletAddress: '0x1234567890abcdef',
     isActive: false,
@@ -46,6 +49,7 @@ export const mockData: MockedPerson[] = [
     },
   },
   {
+    id: '3',
     firstName: null,
     walletAddress: '0x1234567890abcdef',
     isActive: true,
@@ -61,6 +65,7 @@ export const mockData: MockedPerson[] = [
     },
   },
   {
+    id: '4',
     firstName: 'Diana',
     walletAddress: '0x1234567890abcdef',
     isActive: false,
@@ -76,6 +81,7 @@ export const mockData: MockedPerson[] = [
     },
   },
   {
+    id: '5',
     firstName: null,
     walletAddress: '0x1234567890abcdef',
     isActive: true,
@@ -91,6 +97,7 @@ export const mockData: MockedPerson[] = [
     },
   },
   {
+    id: '6',
     firstName: 'Fiona',
     walletAddress: '0x1234567890abcdef',
     isActive: true,
@@ -106,6 +113,7 @@ export const mockData: MockedPerson[] = [
     },
   },
   {
+    id: '7',
     firstName: 'Alex',
     walletAddress: '0x1234567890abcdef',
     isActive: true,

--- a/src/table/table/object-set-table.stories.tsx
+++ b/src/table/table/object-set-table.stories.tsx
@@ -124,6 +124,15 @@ const meta: Meta<typeof ObjectSetTable> = {
         defaultValue: { summary: '0' },
       },
     },
+    maxRowCount: {
+      control: 'number',
+      description:
+        'The maximum number of rows allowed in the table. When this limit is reached, the add functionality will be disabled to prevent exceeding the maximum.',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: 'Infinity' },
+      },
+    },
     minRowHeight: {
       control: 'text',
       description: 'The minimum height in pixels of the rows.',

--- a/src/table/table/object-set-table.tsx
+++ b/src/table/table/object-set-table.tsx
@@ -64,6 +64,7 @@ const ObjectSetTable = <T extends DataType = DataType>(config: ObjectSetTableCon
       })),
       width: config.width ?? 'auto',
       minRowCount: config.minRowCount ?? 0,
+      maxRowCount: config.maxRowCount ?? Infinity,
       minRowHeight: config.minRowHeight ?? 'auto',
       allowRowSelection: config.allowRowSelection ?? true,
       showRowNumbers: config.showRowNumbers ?? true,

--- a/src/table/table/types.ts
+++ b/src/table/table/types.ts
@@ -36,11 +36,21 @@ export interface ObjectSetTableConfig<T extends DataType> {
 
   /**
    * The minimum number of rows to display in the table. If the data is less than this number,
-   * the table will add empty rows to reach the minimum.
+   * the table will add empty rows to reach the minimum. Rows can not be removed if the data
+   * is less than the minimum.
    *
    * @default 0
    */
   minRowCount?: number
+
+  /**
+   * The maximum number of rows to display in the table. If the data is greater than this number,
+   * the table will add empty rows to reach the maximum. Rows can not be added if the data is
+   * greater than the maximum.
+   *
+   * @default Infinity
+   */
+  maxRowCount?: number
 
   /**
    * The minimum height in pixels of the rows.


### PR DESCRIPTION
## Ticket
https://trello.com/c/aWCV973N/1037-apply-deletion-functionality-to-the-objectsettable

## Description
- Add `maxRowCount` to limit the maximum number of rows to add
- Updated the docs for the new property

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
