### PR TITLE
feat(scalars): add preview pdf and image for success state

### DIFF
--- a/src/ui/components/data-entry/file-input/file-input.test.tsx
+++ b/src/ui/components/data-entry/file-input/file-input.test.tsx
@@ -173,8 +173,9 @@ describe('FileInput Component', () => {
         fileName="test.pdf"
         fileSize={1024}
         showPreview={true}
+        preview="https://www.google.com"
       />
     )
-    expect(screen.getByText('Preview')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Preview/i })).toBeInTheDocument()
   })
 })

--- a/src/ui/components/data-entry/file-input/file-input.tsx
+++ b/src/ui/components/data-entry/file-input/file-input.tsx
@@ -1,16 +1,17 @@
 import React, { useId } from 'react'
 import type { FileInputProps } from './types.js'
 import { cn } from '../../../../scalars/lib/utils.js'
-import { Icon } from '../../icon/icon.js'
 import FileBackground from '../../icon-components/FileBackground.js'
-import { Input } from '../../../../ui/components/data-entry/input/index.js'
-import { FormLabel } from '../../../../scalars/components/fragments/form-label/form-label.js'
-import { FormMessageList } from '../../../../scalars/components/fragments/form-message/index.js'
+
 import { useDropzone } from 'react-dropzone'
 import { formatBytes, getExtensionsFromMimeTypes } from './utils.js'
 import { Button } from '../../../../scalars/components/fragments/button/button.js'
 import { useFileUpload } from './useUploadFile.js'
 import { FileUploadItem } from './sub-components/file-upload-item.js'
+import { Icon } from '../../icon/index.js'
+import { Input } from '../../../../ui/components/data-entry/input/index.js'
+import { FormLabel } from '../../../../scalars/components/fragments/form-label/form-label.js'
+import { FormMessageList } from '../../../../scalars/components/fragments/form-message/index.js'
 
 const FileInput = React.forwardRef<HTMLInputElement, FileInputProps>(
   (
@@ -50,14 +51,26 @@ const FileInput = React.forwardRef<HTMLInputElement, FileInputProps>(
     const hasWarning = Array.isArray(warnings) && warnings.length > 0
     const allowedFileTypesString = Array.isArray(allowedFileTypes) ? allowedFileTypes : []
 
-    const { handleDrop, borderIndicator, preview } = useFileUpload({ value, defaultValue, onChange })
-
+    const {
+      handleDrop,
+      borderIndicator,
+      preview,
+      handleCancelPreview,
+      handleOnPreview,
+      isPreviewOpen,
+      previewStatus,
+      typePreview,
+    } = useFileUpload({
+      value,
+      defaultValue,
+      onChange,
+    })
     const { getInputProps, getRootProps, open, inputRef } = useDropzone({
       onDropAccepted: (acceptedFiles) => {
         handleDrop(acceptedFiles)
       },
-      noClick: true,
-      noKeyboard: true,
+      noClick: status !== 'idle',
+      noKeyboard: status !== 'idle',
     })
 
     return (
@@ -118,8 +131,14 @@ const FileInput = React.forwardRef<HTMLInputElement, FileInputProps>(
                       status={status}
                       onCancel={onCancel}
                       onReload={onReload}
-                      showPreview={showPreview}
+                      // Preview Props
                       preview={preview}
+                      showPreview={showPreview}
+                      handleOnCancelPreview={handleCancelPreview}
+                      isPreviewOpen={isPreviewOpen}
+                      handleOnPreview={() => void handleOnPreview()}
+                      previewStatus={previewStatus}
+                      typePreview={typePreview}
                     />
                   </div>
                 </div>

--- a/src/ui/components/data-entry/file-input/sub-components/file-upload-item.tsx
+++ b/src/ui/components/data-entry/file-input/sub-components/file-upload-item.tsx
@@ -1,11 +1,19 @@
-import { useState } from 'react'
 import { cn } from '../../../../../scalars/lib/utils.js'
-import { ProgressBar } from '../../../../../scalars/components/fragments/progress-bar/progress-bar.js'
-import { Icon } from '../../../icon/icon.js'
+import { ProgressBar } from '../../../../../scalars/components/fragments/progress-bar/index.js'
+import { Icon } from '../../../icon/index.js'
 import { FormMessageList } from '../../../../../scalars/components/fragments/form-message/message-list.js'
-import type { UploadFile } from '../types.js'
+import type { PreviewStatus, PreviewType, UploadFile } from '../types.js'
 import { getIconKey, MESSAGES } from '../utils.js'
-import { AlertDialog, AlertDialogContent } from '../../../confirm/alert-dialog.js'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+} from '../../../confirm/alert-dialog.js'
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
+import PreviewFilePreview from './preview-file.js'
+import PreviewImagePreview from './preview-image.js'
+import { UnsupportedFile } from './place-holder-unsupported.js'
 
 interface FileUploadItemProps {
   fileName?: string
@@ -17,11 +25,18 @@ interface FileUploadItemProps {
   mimeType?: string
   errorsUpload?: string[]
   status?: UploadFile
+
+  // Preview Props
   showPreview?: boolean
   preview?: string
+  isPreviewOpen?: boolean
+  handleOnPreview?: () => void
+  handleOnCancelPreview?: () => void
+  previewStatus: PreviewStatus
+  typePreview: PreviewType
 }
 
-export const FileUploadItem = ({
+const FileUploadItem = ({
   fileName = '',
   fileSize = '',
   progress = undefined,
@@ -31,10 +46,16 @@ export const FileUploadItem = ({
   mimeType = '',
   errorsUpload,
   status = 'idle',
+
+  // Preview Props
   showPreview,
   preview,
+  isPreviewOpen,
+  handleOnPreview,
+  handleOnCancelPreview = () => null,
+  previewStatus,
+  typePreview,
 }: FileUploadItemProps) => {
-  const [isPreviewOpen, setIsPreviewOpen] = useState(false)
   const showProgress = status === 'uploading' && progress !== undefined && progress >= 0 && progress < 100
   const showSuccess = status === 'success'
   const showError = status === 'error'
@@ -49,11 +70,6 @@ export const FileUploadItem = ({
   const handleOnReload = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
     onReload?.(e)
-  }
-
-  const handleOnPreview = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation()
-    setIsPreviewOpen(true)
   }
 
   return (
@@ -85,7 +101,7 @@ export const FileUploadItem = ({
                 className="text-gray-400 hover:text-gray-600 transition-colors"
                 aria-label="Reload upload"
               >
-                <Icon name="Reload" size={16} className="text-gray-900" />
+                {/* <Icon name="Reload" size={16} className="text-gray-900" /> */}
               </button>
             )}
 
@@ -130,11 +146,31 @@ export const FileUploadItem = ({
       </div>
       {showPreview && (
         <AlertDialog open={isPreviewOpen}>
-          <AlertDialogContent>
-            <div className="flex flex-col gap-2 w-[500px] h-[600px] mt-2">
-              {/* TODO: Add component to show the preview */}
-              <img src={preview} alt="preview" className="w-full h-full" />
-            </div>
+          <VisuallyHidden>
+            <AlertDialogTitle>Preview</AlertDialogTitle>
+          </VisuallyHidden>
+          <VisuallyHidden>
+            <AlertDialogDescription>Preview of the file</AlertDialogDescription>
+          </VisuallyHidden>
+          <AlertDialogContent className="p-0 w-auto h-auto max-w-none">
+            {typePreview === 'pdf' && (
+              <PreviewFilePreview
+                className="w-[500px] h-[652px]"
+                status={previewStatus}
+                onClose={handleOnCancelPreview}
+                preview={preview}
+              />
+            )}
+            {typePreview === 'image' && (
+              <PreviewImagePreview
+                className="w-[368px] h-[384px]"
+                status={previewStatus}
+                onClose={handleOnCancelPreview}
+                preview={preview}
+              />
+            )}
+            {typePreview === 'unknown' && <UnsupportedFile status={previewStatus} onClose={handleOnCancelPreview} />}
+            {typePreview === 'audio' && <div>Recording</div>}
           </AlertDialogContent>
         </AlertDialog>
       )}
@@ -143,3 +179,7 @@ export const FileUploadItem = ({
     </div>
   )
 }
+
+FileUploadItem.displayName = 'FileUploadItem'
+
+export { FileUploadItem }

--- a/src/ui/components/data-entry/file-input/sub-components/place-holder-image.tsx
+++ b/src/ui/components/data-entry/file-input/sub-components/place-holder-image.tsx
@@ -1,0 +1,50 @@
+import { PREVIEW_STATUS, type PreviewStatus } from '../types.js'
+import { STATUS_CONFIG_IMAGE } from '../utils.js'
+import { cn } from '../../../../../scalars/lib/utils.js'
+import { Icon } from '../../../icon/index.js'
+import PreviewHeader from './preview-header.js'
+import LoadingBar from './loading-bar.js'
+
+interface FilePreviewStateProps {
+  status: PreviewStatus
+  onClose: () => void
+  className?: string
+}
+
+export const PlaceHolderImage = ({ status, onClose, className }: FilePreviewStateProps) => {
+  const config = STATUS_CONFIG_IMAGE[status]
+  const icon = config.icon
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col bg-white rounded-md shadow-[1px_4px_15px_0px_rgba(74,88,115,0.25)] px-6 py-4 gap-4',
+        className
+      )}
+    >
+      <PreviewHeader status={status} onClose={onClose} title="Image Preview" />
+      <div className="flex flex-col items-center justify-center bg-gray-100 w-full rounded-md overflow-hidden flex-1">
+        {icon && (
+          <div className="relative">
+            <Icon name={icon} size={128} className="text-gray-300" />
+          </div>
+        )}
+
+        <div className="flex flex-col items-center justify-center gap-4">
+          {config.title && <h3 className="text-xl font-bold leading-6 text-gray-500">{config.title}</h3>}
+          {status === PREVIEW_STATUS.LOADING && <LoadingBar progress={50} className="w-[272px]" />}
+          {status !== PREVIEW_STATUS.CORRUPTED_FILE && config.message && (
+            <p className="text-center text-sm text-gray-500 mx-auto max-w-[296px] whitespace-pre-line">
+              {config.message}
+            </p>
+          )}
+        </div>
+      </div>
+      {status === PREVIEW_STATUS.CORRUPTED_FILE && (
+        <div className=" border-gray-200">
+          <p className="text-xs text-red-900 font-normal leading-4.5">{config.message}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ui/components/data-entry/file-input/sub-components/place-holder-pdf.tsx
+++ b/src/ui/components/data-entry/file-input/sub-components/place-holder-pdf.tsx
@@ -1,0 +1,56 @@
+import PreviewHeader from './preview-header.js'
+import { PREVIEW_STATUS, type PreviewStatus } from '../types.js'
+import LoadingBar from './loading-bar.js'
+import { STATUS_CONFIG_PDF } from '../utils.js'
+import { cn } from '../../../../../scalars/lib/utils.js'
+import { Icon } from '../../../icon/index.js'
+
+interface PlaceHolderPdfProps {
+  status: PreviewStatus
+  onClose: () => void
+  className?: string
+}
+
+export const PlaceHolderPdf = ({ status, onClose, className }: PlaceHolderPdfProps) => {
+  const config = STATUS_CONFIG_PDF[status]
+  const icon = config.icon
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col bg-white rounded-md shadow-[1px_4px_15px_0px_rgba(37, 44, 56, 0.25)] px-6 py-4 gap-4  border border-gray-200 h-[652px] w-[500px]',
+        className
+      )}
+    >
+      <PreviewHeader status={status} onClose={onClose} />
+      <div
+        className={cn(
+          'flex-1 min-h-0 flex flex-col items-center justify-center bg-gray-100 w-full overflow-auto rounded-md',
+          status === PREVIEW_STATUS.LOADING && 'gap-8',
+          status !== PREVIEW_STATUS.LOADING && 'gap-4'
+        )}
+      >
+        {icon && (
+          <div className="relative">
+            <Icon name={icon} size={256} className="text-gray-300" />
+          </div>
+        )}
+
+        <div className="flex flex-col items-center justify-center gap-4">
+          {config.title && <h3 className="text-xl font-bold leading-6 text-gray-500">{config.title}</h3>}
+          {status === PREVIEW_STATUS.LOADING && <LoadingBar progress={50} className="w-[375px]" />}
+          {status === PREVIEW_STATUS.UNSUPPORTED_FORMAT && (
+            <p className="text-center text-sm text-gray-500 mx-auto max-w-[375px] whitespace-pre-line">
+              {config.message}
+            </p>
+          )}
+        </div>
+      </div>
+      {status === PREVIEW_STATUS.CORRUPTED_FILE && (
+        <div className=" border-gray-200">
+          <p className="text-xs text-red-900 font-normal leading-4.5">{config.message}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ui/components/data-entry/file-input/sub-components/place-holder-unsupported.tsx
+++ b/src/ui/components/data-entry/file-input/sub-components/place-holder-unsupported.tsx
@@ -1,0 +1,40 @@
+import PreviewHeader from './preview-header.js'
+import type { PreviewStatus } from '../types.js'
+import { STATUS_CONFIG_PDF } from '../utils.js'
+import { cn } from '../../../../../scalars/lib/utils.js'
+import { Icon } from '../../../icon/index.js'
+
+interface PlaceHolderPdfProps {
+  status: PreviewStatus
+  onClose: () => void
+}
+
+export const UnsupportedFile = ({ status, onClose }: PlaceHolderPdfProps) => {
+  const config = STATUS_CONFIG_PDF.unsupported_format
+  const icon = config.icon
+
+  return (
+    <div className="flex flex-col bg-white rounded-md shadow-[1px_4px_15px_0px_rgba(37, 44, 56, 0.25)] px-6 py-4 gap-4  border border-gray-200 h-[652px] w-[500px]">
+      <PreviewHeader status={status} onClose={onClose} />
+      <div
+        className={cn(
+          'flex-1 min-h-0 flex flex-col items-center justify-center bg-gray-100 w-full overflow-auto rounded-md'
+        )}
+      >
+        {icon && (
+          <div className="relative">
+            <Icon name={icon} size={256} className="text-gray-300" />
+          </div>
+        )}
+
+        <div className="flex flex-col items-center justify-center gap-4">
+          {config.title && <h3 className="text-xl font-bold leading-6 text-gray-500">{config.title}</h3>}
+
+          <p className="text-center text-sm text-gray-500 mx-auto max-w-[375px] whitespace-pre-line">
+            {config.message}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/ui/components/data-entry/file-input/sub-components/preview-file.tsx
+++ b/src/ui/components/data-entry/file-input/sub-components/preview-file.tsx
@@ -1,71 +1,41 @@
 import { cn } from '../../../../../scalars/lib/utils.js'
-import { Icon } from '../../../icon/index.js'
 import { PREVIEW_STATUS, type PreviewStatus } from '../types.js'
-import { STATUS_CONFIG } from '../utils.js'
-import LoadingBar from './loading-bar.js'
+import { PlaceHolderPdf } from './place-holder-pdf.js'
+import PreviewHeader from './preview-header.js'
 
 interface FilePreviewStateProps {
+  onClose?: () => void
+  preview?: string
+  className?: string
   status: PreviewStatus
-  onClose: () => void
-  title?: string
-  message?: string
 }
 
-const PreviewFilePreview = ({
-  status,
-  onClose,
-  title: overrideTitle,
-  message: overrideMessage,
-}: FilePreviewStateProps) => {
-  const config = STATUS_CONFIG[status]
-
-  const isLoading = status === PREVIEW_STATUS.LOADING
-  const isCorrupted = status === PREVIEW_STATUS.CORRUPTED_FILE
-
-  const title = overrideTitle ?? config.title
-  const message = overrideMessage ?? config.message
-  const icon = config.icon
+const PreviewFilePreview = ({ status, onClose = () => null, preview, className }: FilePreviewStateProps) => {
+  const isIframeVisible = status === PREVIEW_STATUS.SUCCESS
 
   return (
-    <div className="flex flex-col bg-white rounded-md shadow-[1px_4px_15px_0px_rgba(74,88,115,0.25)] px-6 py-4 gap-4 w-full h-full min-h-0">
-      <header className="flex justify-between items-center">
-        <span className={cn('text-gray-900 text-sm font-normal leading-4.5', isCorrupted && 'text-red-900')}>
-          Preview
-        </span>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close preview"
-          className="text-gray-400 hover:text-gray-600"
-        >
-          <Icon name="XmarkLight" size={16} className="text-gray-900" />
-        </button>
-      </header>
-
-      <div
-        className={cn(
-          'flex-1 min-h-0 flex flex-col items-center justify-center bg-gray-100 w-full overflow-auto rounded-md',
-          isLoading && 'gap-8',
-          !isLoading && 'gap-4'
-        )}
-      >
-        <div className="relative">
-          <Icon name={icon} size={256} className="text-gray-300" />
-        </div>
-
-        <div className="flex flex-col items-center justify-center gap-4">
-          {title && <h3 className="text-xl font-bold leading-6 text-gray-500">{title}</h3>}
-          {isLoading && <LoadingBar progress={50} className="w-[375px]" />}
-          {!isCorrupted && message && (
-            <p className="text-center text-sm text-gray-500 mx-auto max-w-[375px] whitespace-pre-line">{message}</p>
-          )}
-        </div>
-      </div>
-      {isCorrupted && (
-        <div className=" border-gray-200">
-          <p className="text-xs text-red-900 font-normal leading-4.5">{message}</p>
-        </div>
+    <div
+      className={cn(
+        'relative flex flex-col bg-white rounded-md shadow-[1px_4px_15px_0px_rgba(74,88,15,0.25)] px-6 py-4 gap-4 w-full h-full',
+        className
       )}
+    >
+      <PreviewHeader status={status} onClose={onClose} />
+
+      <div className="flex-1 relative">
+        {preview && (
+          <div className="absolute inset-0 rounded-md overflow-hidden">
+            <iframe
+              src={`${preview}#toolbar=0&navpanes=0&scrollbar=0`}
+              title="Previsualización de PDF"
+              className="w-full h-full border-none"
+            >
+              <p>Your browser does not support the preview.</p>
+            </iframe>
+          </div>
+        )}
+      </div>
+      {!isIframeVisible && <PlaceHolderPdf status={status} onClose={onClose} className="absolute inset-0 z-20" />}
     </div>
   )
 }

--- a/src/ui/components/data-entry/file-input/sub-components/preview-header.tsx
+++ b/src/ui/components/data-entry/file-input/sub-components/preview-header.tsx
@@ -1,0 +1,29 @@
+import { cn } from '../../../../../scalars/lib/utils.js'
+import { Icon } from '../../../icon/index.js'
+import { PREVIEW_STATUS, type PreviewStatus } from '../types.js'
+
+interface PreviewHeaderProps {
+  status: PreviewStatus
+  onClose: () => void
+  title?: string
+}
+
+const PreviewHeader = ({ status, onClose, title = 'File Preview' }: PreviewHeaderProps) => {
+  return (
+    <header className="flex justify-between items-center">
+      <span
+        className={cn(
+          'text-gray-900 text-sm font-normal leading-4.5',
+          status === PREVIEW_STATUS.CORRUPTED_FILE && 'text-red-900'
+        )}
+      >
+        {title}
+      </span>
+      <button type="button" onClick={onClose} aria-label="Close preview" className="text-gray-400 hover:text-gray-600">
+        <Icon name="XmarkLight" size={16} className="text-gray-900" />
+      </button>
+    </header>
+  )
+}
+
+export default PreviewHeader

--- a/src/ui/components/data-entry/file-input/sub-components/preview-image.tsx
+++ b/src/ui/components/data-entry/file-input/sub-components/preview-image.tsx
@@ -1,69 +1,33 @@
 import { cn } from '../../../../../scalars/lib/utils.js'
-import { Icon } from '../../../icon/index.js'
 import { PREVIEW_STATUS, type PreviewStatus } from '../types.js'
-import { STATUS_CONFIG } from '../utils.js'
-import LoadingBar from './loading-bar.js'
-
-type ImagePreviewStatus = Exclude<PreviewStatus, typeof PREVIEW_STATUS.GENERIC_ERROR>
+import { PlaceHolderImage } from './place-holder-image.js'
+import PreviewHeader from './preview-header.js'
 
 interface FilePreviewStateProps {
-  status: ImagePreviewStatus
+  status: PreviewStatus
   onClose: () => void
-  title?: string
-  message?: string
+  className?: string
+  preview?: string
 }
 
-const PreviewImagePreview = ({
-  status,
-  onClose,
-  title: overrideTitle,
-  message: overrideMessage,
-}: FilePreviewStateProps) => {
-  const config = STATUS_CONFIG[status]
-
-  const isLoading = status === PREVIEW_STATUS.LOADING
-  const isCorrupted = status === PREVIEW_STATUS.CORRUPTED_FILE
-
-  const title = overrideTitle ?? config.title
-  const message = overrideMessage ?? config.message
-  const icon = config.icon
-
-  return (
-    <div className="flex flex-col bg-white rounded-md shadow-[1px_4px_15px_0px_rgba(74,88,115,0.25)] px-6 py-4 gap-4 w-full h-full min-h-0">
-      <header className="flex justify-between items-center">
-        <span className={cn('text-gray-900 text-sm font-normal leading-4.5', isCorrupted && 'text-red-900')}>
-          Image Preview
-        </span>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close preview"
-          className="text-gray-400 hover:text-gray-600"
-        >
-          <Icon name="XmarkLight" size={16} className="text-gray-900" />
-        </button>
-      </header>
-
-      <div className="flex-1 min-h-0 flex flex-col items-center justify-center bg-gray-100 w-full overflow-auto rounded-md">
-        <div className="relative">
-          <Icon name={icon} size={128} className="text-gray-300" />
-        </div>
-
-        <div className="flex flex-col items-center justify-center gap-4">
-          {title && <h3 className="text-xl font-bold leading-6 text-gray-500">{title}</h3>}
-          {isLoading && <LoadingBar progress={50} className="w-[272px]" />}
-          {!isCorrupted && message && (
-            <p className="text-center text-sm text-gray-500 mx-auto max-w-[296px] whitespace-pre-line">{message}</p>
-          )}
+const PreviewImagePreview = ({ status, onClose, className, preview }: FilePreviewStateProps) => {
+  if (status === PREVIEW_STATUS.SUCCESS) {
+    return (
+      <div
+        className={cn(
+          'flex flex-col bg-white rounded-md shadow-[1px_4px_15px_0px_rgba(74,88,115,0.25)] px-6 py-4 gap-4 w-full h-full',
+          className
+        )}
+      >
+        <PreviewHeader status={status} onClose={onClose} title="Image Preview" />
+        <div className="flex justify-center items-center relative rounded-md overflow-hidden">
+          {preview && <img src={preview} alt="Preview" className="w-full h-full object-contain" />}
         </div>
       </div>
-      {isCorrupted && (
-        <div className=" border-gray-200">
-          <p className="text-xs text-red-900 font-normal leading-4.5">{message}</p>
-        </div>
-      )}
-    </div>
-  )
+    )
+  }
+
+  return <PlaceHolderImage status={status} onClose={onClose} className={className} />
 }
 
 export default PreviewImagePreview

--- a/src/ui/components/data-entry/file-input/types.ts
+++ b/src/ui/components/data-entry/file-input/types.ts
@@ -19,6 +19,7 @@ export interface FileInputProps
   errorsUpload?: string[]
   status?: UploadFile
   showPreview?: boolean
+  preview?: string
 }
 
 export type UploadFile = 'idle' | 'uploading' | 'success' | 'error'
@@ -26,15 +27,17 @@ export type UploadFile = 'idle' | 'uploading' | 'success' | 'error'
 export const PREVIEW_STATUS = {
   LOADING: 'loading',
   UNSUPPORTED_FORMAT: 'unsupported_format',
-  GENERIC_ERROR: 'generic_error',
   CORRUPTED_FILE: 'corrupted_file',
+  SUCCESS: 'success',
 } as const
 
 type ValueOf<T> = T[keyof T]
 export type PreviewStatus = ValueOf<typeof PREVIEW_STATUS>
 
 export interface StatusConfig {
-  icon: IconName
-  title: string
-  message: string
+  icon: IconName | undefined
+  title?: string
+  message?: string
 }
+
+export type PreviewType = 'pdf' | 'image' | 'audio' | 'unknown'

--- a/src/ui/components/data-entry/file-input/useUploadFile.ts
+++ b/src/ui/components/data-entry/file-input/useUploadFile.ts
@@ -1,12 +1,26 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { PREVIEW_STATUS, type PreviewStatus } from './types.js'
+import { detectPreviewType, validateImageHeader, validatePdfHeader } from './utils.js'
+
 interface UseFileUploadProps {
   value?: File | null
   defaultValue?: File | null
   onChange?: (file: File | null) => void
 }
+
+const mapValidator = {
+  ['pdf']: validatePdfHeader,
+  ['image']: validateImageHeader,
+  ['audio']: async () => Promise.resolve(true),
+  ['unknown']: async () => Promise.resolve(false),
+}
+
 export const useFileUpload = ({ value, defaultValue, onChange }: UseFileUploadProps) => {
   const [file, setFile] = useState<File | null>(value ?? defaultValue ?? null)
   const [preview, setPreview] = useState<string | undefined>(undefined)
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false)
+  const [previewStatus, setPreviewStatus] = useState<PreviewStatus>(PREVIEW_STATUS.LOADING)
+
   const handleDrop = useCallback(
     (acceptedFiles?: File[]) => {
       if (!acceptedFiles || acceptedFiles.length === 0) return
@@ -19,7 +33,63 @@ export const useFileUpload = ({ value, defaultValue, onChange }: UseFileUploadPr
     [onChange]
   )
 
+  const handleCancelPreview = () => {
+    setIsPreviewOpen(false)
+  }
+
+  const typePreview = detectPreviewType(file?.type)
+
+  const handleOnPreview = async () => {
+    setIsPreviewOpen(true)
+    setPreviewStatus(PREVIEW_STATUS.LOADING)
+
+    if (!file || typePreview === 'unknown') {
+      setPreviewStatus(PREVIEW_STATUS.UNSUPPORTED_FORMAT)
+      return
+    }
+
+    const validator = mapValidator[typePreview]
+
+    try {
+      const isValid = await validator(file)
+
+      if (!isValid) {
+        setPreviewStatus(PREVIEW_STATUS.CORRUPTED_FILE)
+        return
+      }
+
+      if (!preview) {
+        setPreviewStatus(PREVIEW_STATUS.CORRUPTED_FILE)
+        return
+      }
+      await new Promise((res) => setTimeout(res, 2000))
+      setPreviewStatus(PREVIEW_STATUS.SUCCESS)
+    } catch {
+      setPreviewStatus(PREVIEW_STATUS.CORRUPTED_FILE)
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      if (preview) {
+        URL.revokeObjectURL(preview)
+      }
+    }
+  }, [preview])
+
   const borderIndicator = file ? 'text-blue-900' : 'text-gray-300'
 
-  return { handleDrop, file, borderIndicator, preview }
+  return {
+    handleDrop,
+    file,
+    borderIndicator,
+    // Preview
+    preview,
+    handleCancelPreview,
+    handleOnPreview,
+    isPreviewOpen,
+    previewStatus,
+    setPreviewStatus,
+    typePreview,
+  }
 }

--- a/src/ui/components/data-entry/file-input/utils.ts
+++ b/src/ui/components/data-entry/file-input/utils.ts
@@ -57,7 +57,7 @@ export const getIconKey = (mimeType: string): IconName => {
   return iconName
 }
 
-export const STATUS_CONFIG: Record<PreviewStatus, StatusConfig> = {
+export const STATUS_CONFIG_PDF: Record<PreviewStatus, StatusConfig> = {
   [PREVIEW_STATUS.LOADING]: {
     icon: 'BookOpenText',
     title: 'Loading',
@@ -69,14 +69,95 @@ export const STATUS_CONFIG: Record<PreviewStatus, StatusConfig> = {
     message:
       "It looks like we still don't support this format. (We are working on it) Please try to upload it with a different Format.",
   },
-  [PREVIEW_STATUS.GENERIC_ERROR]: {
-    icon: 'ContentUnavailableIcon',
-    title: 'Opss!',
-    message: 'It looks like your file has an error.\nPlease try again',
-  },
   [PREVIEW_STATUS.CORRUPTED_FILE]: {
     icon: 'ContentUnavailableIcon',
     title: '',
     message: 'Your file is corrupted and cannot be shown in the preview',
   },
+  [PREVIEW_STATUS.SUCCESS]: {
+    icon: undefined,
+    title: '',
+    message: '',
+  },
+}
+export const STATUS_CONFIG_IMAGE: Record<PreviewStatus, StatusConfig> = {
+  [PREVIEW_STATUS.LOADING]: {
+    icon: 'Image',
+    title: 'Loading',
+    message: '',
+  },
+  [PREVIEW_STATUS.UNSUPPORTED_FORMAT]: {
+    icon: 'BrokenImage',
+    title: 'Opss!',
+    message:
+      "It looks like we still don't support this format. (We are working on it) Please try to upload it with a different Format.",
+  },
+  [PREVIEW_STATUS.CORRUPTED_FILE]: {
+    icon: 'BrokenImage',
+    title: '',
+    message: 'Your file is corrupted and cannot be shown in the preview',
+  },
+  [PREVIEW_STATUS.SUCCESS]: {
+    icon: undefined,
+    title: '',
+    message: '',
+  },
+}
+
+const MIME_TYPE_TO_EXTENSION_IMAGE = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+}
+
+const MIME_TYPE_TO_EXTENSION_AUDIO = {
+  'audio/mpeg': 'mp3',
+  'audio/wav': 'wav',
+  'audio/ogg': 'ogg',
+  'audio/aac': 'aac',
+  'audio/m4a': 'm4a',
+}
+
+const MIME_TYPE_TO_EXTENSION_PDF = {
+  'application/pdf': 'pdf',
+}
+
+export const detectPreviewType = (mimeType?: string): 'pdf' | 'image' | 'audio' | 'unknown' => {
+  if (!mimeType) return 'unknown'
+  if (Object.keys(MIME_TYPE_TO_EXTENSION_IMAGE).includes(mimeType)) return 'image'
+  if (Object.keys(MIME_TYPE_TO_EXTENSION_AUDIO).includes(mimeType)) return 'audio'
+  if (Object.keys(MIME_TYPE_TO_EXTENSION_PDF).includes(mimeType)) return 'pdf'
+  return 'unknown'
+}
+
+export const validatePdfHeader = async (file: File) => {
+  const buffer = await file.arrayBuffer()
+  const text = new TextDecoder().decode(buffer)
+
+  const hasHeader = text.startsWith('%PDF-')
+  const hasEOF = text.includes('%%EOF')
+  const hasXref = text.includes('xref')
+  const hasTrailer = text.includes('trailer')
+
+  return hasHeader && hasEOF && hasXref && hasTrailer
+}
+
+export const validateImageHeader = async (file: File) => {
+  return new Promise((resolve) => {
+    const url = URL.createObjectURL(file)
+    const img = new Image()
+
+    img.onload = () => {
+      URL.revokeObjectURL(url)
+      resolve(true)
+    }
+
+    img.onerror = () => {
+      URL.revokeObjectURL(url)
+      resolve(false)
+    }
+
+    img.src = url
+  })
 }


### PR DESCRIPTION
## Ticket
https://trello.com/c/vERepv6Q/1097-implement-preview-functionality-for-the-file-component

## Description
- Should the component render the unsupported types UI

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
