### PR TITLE
fix(scalars): disable the carets when disable props is true

### DIFF
--- a/src/ui/components/data-entry/number-input/number-input.tsx
+++ b/src/ui/components/data-entry/number-input/number-input.tsx
@@ -111,7 +111,7 @@ const NumberInputRaw = forwardRef<HTMLInputElement, InputNumberPropsWithDifferen
               <div className="absolute inset-y-2 right-3 flex flex-col justify-center group-focus-within:opacity-100 transition-opacity">
                 <button
                   aria-label="Increment"
-                  disabled={canIncrement}
+                  disabled={canIncrement || props.disabled}
                   onMouseDown={(e) => {
                     e.preventDefault()
                   }}
@@ -126,7 +126,10 @@ const NumberInputRaw = forwardRef<HTMLInputElement, InputNumberPropsWithDifferen
                   <Icon
                     size={10}
                     name="ChevronDown"
-                    className={cn('rotate-180 text-gray-700 dark:text-gray-300', canIncrement && 'cursor-not-allowed')}
+                    className={cn(
+                      'rotate-180 text-gray-700 dark:text-gray-300',
+                      (canIncrement || props.disabled) && 'cursor-not-allowed'
+                    )}
                   />
                 </button>
                 <button
@@ -134,7 +137,7 @@ const NumberInputRaw = forwardRef<HTMLInputElement, InputNumberPropsWithDifferen
                   onMouseDown={(e) => {
                     e.preventDefault()
                   }}
-                  disabled={canDecrement}
+                  disabled={canDecrement || props.disabled}
                   type="button"
                   onClick={(e) => {
                     stepValueHandler(e, 'decrement')
@@ -148,7 +151,7 @@ const NumberInputRaw = forwardRef<HTMLInputElement, InputNumberPropsWithDifferen
                     name="ChevronDown"
                     className={cn(
                       'items-center justify-center text-gray-700 dark:text-gray-300',
-                      canDecrement && 'cursor-not-allowed'
+                      (canDecrement || props.disabled) && 'cursor-not-allowed'
                     )}
                   />
                 </button>


### PR DESCRIPTION
## Ticket
https://trello.com/c/vEINL1Gh/1161-make-the-increment-decrement-carets-configurable

## Description
**Environment:** Storybook, Connect **Browser:** Chrome **Steps to Reproduce:** NumberField/AmountField, Disable story. Setting enableStepCarets = true. **Expected Output:** The field should not be editable/interactive including the carets. **Current Output:** The user is able to use to use the carets because they are not disabled. 

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
<img width="989" height="375" alt="number-input" src="https://github.com/user-attachments/assets/3d88e823-6031-4ddf-86b2-c8a0f98a8f13" />
<img width="818" height="237" alt="image" src="https://github.com/user-attachments/assets/f4adab1a-e2dd-401e-91ab-4f421b3ac38e" />

