### PR TITLE
feat(scalars): add background and color to the selected node

### DIFF
--- a/src/ui/components/sidebar/subcomponents/sidebar-item.tsx
+++ b/src/ui/components/sidebar/subcomponents/sidebar-item.tsx
@@ -119,7 +119,8 @@ export const SidebarItem = ({
               // line between pinned items
               pinnedMode &&
                 'after:absolute after:-top-2.5 after:left-[15px] after:h-4 after:w-px after:bg-gray-300 hover:bg-gray-50 first:group-first/sidebar-item-wrapper:after:hidden dark:hover:bg-slate-600',
-              isActive && 'font-medium text-gray-900 dark:text-gray-50'
+              isActive &&
+                'font-medium text-gray-900 dark:text-gray-50 bg-gray-200 hover:bg-gray-200 dark:bg-charcoal-900 dark:hover:bg-charcoal-900'
             )}
             onClick={handleClick}
           >


### PR DESCRIPTION
## Ticket
https://trello.com/c/2EjkcZti/1169-allow-sidebar-selected-node-to-have-a-bg-color

## Description
- Should apply a bg-color for the selected node. [design]

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
<img width="1859" height="925" alt="image" src="https://github.com/user-attachments/assets/d07c92e6-4304-4716-8f3d-f10521891e16" />
<img width="1096" height="975" alt="image" src="https://github.com/user-attachments/assets/92fa3019-ada9-4182-ab20-23897ab1ebdf" />

