### PR TITLE
fix(scalars & ui): focus on IdAutocomplete based fields

### DIFF
--- a/src/scalars/components/aid-field/__snapshots__/aid-field.test.tsx.snap
+++ b/src/scalars/components/aid-field/__snapshots__/aid-field.test.tsx.snap
@@ -31,14 +31,11 @@ exports[`AIDField Component > should match snapshot 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-controls="radix-:r4:"
             aria-expanded="false"
             aria-invalid="false"
-            aria-labelledby="radix-:r5:"
             autocomplete="off"
             autocorrect="off"
             class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-9"
-            cmdk-input=""
             id=":r1:-aid"
             name="aid"
             placeholder="did:ethr:"

--- a/src/scalars/components/fragments/id-autocomplete/__snapshots__/id-autocomplete.test.tsx.snap
+++ b/src/scalars/components/fragments/id-autocomplete/__snapshots__/id-autocomplete.test.tsx.snap
@@ -27,14 +27,11 @@ exports[`IdAutocomplete Component > should match snapshot 1`] = `
       >
         <input
           aria-autocomplete="list"
-          aria-controls="radix-:r2:"
           aria-expanded="false"
           aria-invalid="false"
-          aria-labelledby="radix-:r3:"
           autocomplete="off"
           autocorrect="off"
           class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-9"
-          cmdk-input=""
           id=":r0:-id-autocomplete"
           name="id-autocomplete"
           placeholder="Search..."

--- a/src/scalars/components/fragments/id-autocomplete/id-autocomplete-input-container.tsx
+++ b/src/scalars/components/fragments/id-autocomplete/id-autocomplete-input-container.tsx
@@ -1,6 +1,5 @@
 import { Icon } from '../../../../ui/components/icon/index.js'
 import { cn } from '../../../../scalars/lib/index.js'
-import { Command as CommandPrimitive } from 'cmdk'
 import React, { useMemo, useState } from 'react'
 import { useMediaQuery } from 'usehooks-ts'
 import { Input } from '../../../../ui/components/data-entry/input/index.js'
@@ -71,59 +70,63 @@ const IdAutocompleteInputContainer = React.forwardRef<HTMLInputElement, IdAutoco
     return (
       <div className={cn('group relative')}>
         <ValueTransformer transformers={transformers}>
-          <CommandPrimitive.Input asChild>
-            <Input
-              id={id}
-              name={name}
-              value={value}
-              className={cn('pr-9', className)}
-              disabled={disabled}
-              onChange={onChange}
-              onBlur={onBlur}
-              onClick={(e) => {
-                const input = e.target as HTMLInputElement
-                if (!(isLoading || haveFetchError) && !selectedOption && input.value !== '') {
-                  handleOpenChange?.(true)
-                }
-                onClick?.(e)
-              }}
-              onKeyDown={(e) => {
-                onKeyDown?.(e)
-                const isOptionsRelatedKey = ['ArrowUp', 'ArrowDown', 'Enter'].includes(e.key)
+          <Input
+            id={id}
+            name={name}
+            value={value}
+            className={cn('pr-9', className)}
+            disabled={disabled}
+            onChange={onChange}
+            onBlur={onBlur}
+            onClick={(e) => {
+              const input = e.target as HTMLInputElement
+              if (!(isLoading || haveFetchError) && !selectedOption && input.value !== '') {
+                handleOpenChange?.(true)
+              }
+              onClick?.(e)
+            }}
+            onKeyDown={(e) => {
+              onKeyDown?.(e)
+              const isOptionsRelatedKey = ['ArrowUp', 'ArrowDown', 'Enter'].includes(e.key)
 
-                if (e.key === 'Enter' && isPopoverOpen && optionsLength === 0) {
-                  handleOpenChange?.(false)
-                  e.preventDefault()
-                  return
-                }
-                if (!(isOptionsRelatedKey && isPopoverOpen && optionsLength > 0)) {
-                  e.stopPropagation()
-                }
-              }}
-              onMouseDown={(e) => {
-                const input = e.target as HTMLInputElement
-                if (!input.contains(document.activeElement)) {
-                  // wait for the next tick to ensure the focus occurs first
-                  requestAnimationFrame(() => {
-                    input.select()
-                  })
-                }
-                onMouseDown?.(e)
-              }}
-              onPaste={(e) => {
-                handlePaste?.(e)
-                onPaste?.(e)
-              }}
-              placeholder={placeholder}
-              aria-invalid={hasError}
-              aria-label={!label ? 'Id Autocomplete' : undefined}
-              aria-required={required}
-              aria-expanded={isPopoverOpen}
-              maxLength={maxLength}
-              {...props}
-              ref={ref}
-            />
-          </CommandPrimitive.Input>
+              if (e.key === 'Enter' && isPopoverOpen && optionsLength === 0) {
+                handleOpenChange?.(false)
+                e.preventDefault()
+                return
+              }
+              if (!(isOptionsRelatedKey && isPopoverOpen && optionsLength > 0)) {
+                e.stopPropagation()
+              }
+            }}
+            onMouseDown={(e) => {
+              const input = e.target as HTMLInputElement
+              if (!input.contains(document.activeElement)) {
+                // wait for the next tick to ensure the focus occurs first
+                requestAnimationFrame(() => {
+                  input.select()
+                })
+              }
+              onMouseDown?.(e)
+            }}
+            onPaste={(e) => {
+              handlePaste?.(e)
+              onPaste?.(e)
+            }}
+            placeholder={placeholder}
+            aria-invalid={hasError}
+            aria-label={!label ? 'Id Autocomplete' : undefined}
+            aria-required={required}
+            aria-expanded={isPopoverOpen}
+            aria-autocomplete="list"
+            autoComplete="off"
+            autoCorrect="off"
+            maxLength={maxLength}
+            role="combobox"
+            spellCheck={false}
+            type="text"
+            {...props}
+            ref={ref}
+          />
         </ValueTransformer>
         <div
           className={cn(

--- a/src/scalars/components/fragments/id-autocomplete/use-id-autocomplete.ts
+++ b/src/scalars/components/fragments/id-autocomplete/use-id-autocomplete.ts
@@ -75,6 +75,7 @@ export function useIdAutocomplete({
               } else {
                 setSelectedOption(undefined)
                 setIsPopoverOpen(true)
+                setCommandValue(newOptions[0]?.value ?? '')
               }
               setIsLoading(false)
             })
@@ -140,7 +141,7 @@ export function useIdAutocomplete({
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
-      if (!open) {
+      if (open) {
         setCommandValue(options[0]?.value ?? '')
       }
       setIsPopoverOpen(open)

--- a/src/scalars/components/oid-field/__snapshots__/oid-field.test.tsx.snap
+++ b/src/scalars/components/oid-field/__snapshots__/oid-field.test.tsx.snap
@@ -31,14 +31,11 @@ exports[`OIDField Component > should match snapshot 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-controls="radix-:r4:"
             aria-expanded="false"
             aria-invalid="false"
-            aria-labelledby="radix-:r5:"
             autocomplete="off"
             autocorrect="off"
             class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-9"
-            cmdk-input=""
             id=":r1:-oid"
             name="oid"
             placeholder="uuid"

--- a/src/scalars/components/phid-field/__snapshots__/phid-field.test.tsx.snap
+++ b/src/scalars/components/phid-field/__snapshots__/phid-field.test.tsx.snap
@@ -31,14 +31,11 @@ exports[`PHIDField Component > should match snapshot 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-controls="radix-:r4:"
             aria-expanded="false"
             aria-invalid="false"
-            aria-labelledby="radix-:r5:"
             autocomplete="off"
             autocorrect="off"
             class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-9"
-            cmdk-input=""
             id=":r1:-phid"
             name="phid"
             placeholder="phd:"

--- a/src/ui/components/data-entry/aid-input/__snapshots__/aid-input.test.tsx.snap
+++ b/src/ui/components/data-entry/aid-input/__snapshots__/aid-input.test.tsx.snap
@@ -27,14 +27,11 @@ exports[`AIDInput Component > should match snapshot 1`] = `
       >
         <input
           aria-autocomplete="list"
-          aria-controls="radix-:r3:"
           aria-expanded="false"
           aria-invalid="false"
-          aria-labelledby="radix-:r4:"
           autocomplete="off"
           autocorrect="off"
           class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-9"
-          cmdk-input=""
           id=":r0:-aid"
           name="aid"
           placeholder="did:ethr:"

--- a/src/ui/components/data-entry/oid-input/__snapshots__/oid-input.test.tsx.snap
+++ b/src/ui/components/data-entry/oid-input/__snapshots__/oid-input.test.tsx.snap
@@ -27,14 +27,11 @@ exports[`OIDInput Component > should match snapshot 1`] = `
       >
         <input
           aria-autocomplete="list"
-          aria-controls="radix-:r3:"
           aria-expanded="false"
           aria-invalid="false"
-          aria-labelledby="radix-:r4:"
           autocomplete="off"
           autocorrect="off"
           class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-9"
-          cmdk-input=""
           id=":r0:-oid"
           name="oid"
           placeholder="uuid"

--- a/src/ui/components/data-entry/phid-input/__snapshots__/phid-input.test.tsx.snap
+++ b/src/ui/components/data-entry/phid-input/__snapshots__/phid-input.test.tsx.snap
@@ -27,14 +27,11 @@ exports[`PHIDInput Component > should match snapshot 1`] = `
       >
         <input
           aria-autocomplete="list"
-          aria-controls="radix-:r3:"
           aria-expanded="false"
           aria-invalid="false"
-          aria-labelledby="radix-:r4:"
           autocomplete="off"
           autocorrect="off"
           class="flex h-9 w-full rounded-md text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-900 focus-visible:ring-offset-0 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-9"
-          cmdk-input=""
           id=":r0:-phid"
           name="phid"
           placeholder="phd:"


### PR DESCRIPTION
## Ticket
https://trello.com/c/gjHqTmQV/1159-input-focus-lost-after-autocomplete-result-found-in-phid-oid-aid-fields

## Description
- Fix focus on IdAutocomplete based fields (Should the focus not be removed after showing the result list)

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings