### PR TITLE
fix(ui): disabled state on PasswordInput

### DIFF
--- a/src/ui/components/data-entry/password-input/password-input.tsx
+++ b/src/ui/components/data-entry/password-input/password-input.tsx
@@ -155,10 +155,16 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
                 {...(!!label && { 'data-label': label })}
                 {...props}
               />
-              <div className={cn('absolute right-3 top-1/2 flex size-4 -translate-y-1/2 items-center')}>
+              <div
+                className={cn(
+                  'absolute right-3 top-1/2 flex size-4 -translate-y-1/2 items-center',
+                  disabled && 'pointer-events-none'
+                )}
+              >
                 <button
                   type="button"
                   aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  disabled={disabled}
                   onClick={() => {
                     setShowPassword(!showPassword)
                   }}


### PR DESCRIPTION
## Ticket
https://trello.com/c/45k6gQ8u/1168-eye-icon-should-be-disabled-if-password-component-is-disabled

## Description
- Fix disabled state on PasswordInput component (Should ensure the eye icon is not interactive when the field is disabled)

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings