### PR TITLE
feat(scalars): add custom class for styled the sideBar

### DIFF
--- a/src/ui/components/sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/src/ui/components/sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Sidebar Component > Loading State > should match snapshot in loading state 1`] = `
 <DocumentFragment>
   <aside
-    class="group peer relative flex h-svh max-h-screen flex-col bg-gray-50 shadow-lg transition-[width] duration-75 ease-linear dark:bg-slate-600"
+    class="group peer relative flex h-svh max-h-screen flex-col bg-gray-50 shadow-lg transition-[width] duration-75 ease-linear dark:bg-slate-600 sidebar__container"
   >
     <header
-      class="flex items-center justify-between gap-2 border-b border-gray-300 bg-gray-50 p-4 dark:border-gray-800 dark:bg-slate-600"
+      class="flex items-center justify-between gap-2 border-b border-gray-300 bg-gray-50 p-4 dark:border-gray-800 dark:bg-slate-600 sidebar__header"
     >
       <div
         class="flex items-center gap-2 truncate"
@@ -36,14 +36,14 @@ exports[`Sidebar Component > Loading State > should match snapshot in loading st
         class="flex select-none items-center gap-2"
       >
         <div
-          class="w-[26px] rounded-lg bg-slate-50 p-1 text-center text-xs text-slate-100 dark:bg-gray-900 dark:text-slate-200 hover:bg-slate-100 hover:text-slate-200 dark:hover:bg-gray-600 dark:hover:text-slate-50"
+          class="w-[26px] rounded-lg bg-slate-50 p-1 text-center text-xs text-slate-100 dark:bg-gray-900 dark:text-slate-200 hover:bg-slate-100 hover:text-slate-200 dark:hover:bg-gray-600 dark:hover:text-slate-50 sidebar__header-macro-item"
           role="button"
           tabindex="2"
         >
           1
         </div>
         <div
-          class="w-[26px] rounded-lg bg-slate-50 p-1 text-center text-xs text-slate-100 dark:bg-gray-900 dark:text-slate-200 hover:bg-slate-100 hover:text-slate-200 dark:hover:bg-gray-600 dark:hover:text-slate-50"
+          class="w-[26px] rounded-lg bg-slate-50 p-1 text-center text-xs text-slate-100 dark:bg-gray-900 dark:text-slate-200 hover:bg-slate-100 hover:text-slate-200 dark:hover:bg-gray-600 dark:hover:text-slate-50 sidebar__header-macro-item"
           role="button"
           tabindex="2"
         >
@@ -313,10 +313,10 @@ exports[`Sidebar Component > Loading State > should match snapshot in loading st
 exports[`Sidebar Component > should match snapshot 1`] = `
 <DocumentFragment>
   <aside
-    class="group peer relative flex h-svh max-h-screen flex-col bg-gray-50 shadow-lg transition-[width] duration-75 ease-linear dark:bg-slate-600"
+    class="group peer relative flex h-svh max-h-screen flex-col bg-gray-50 shadow-lg transition-[width] duration-75 ease-linear dark:bg-slate-600 sidebar__container"
   >
     <header
-      class="flex items-center justify-between gap-2 border-b border-gray-300 bg-gray-50 p-4 dark:border-gray-800 dark:bg-slate-600"
+      class="flex items-center justify-between gap-2 border-b border-gray-300 bg-gray-50 p-4 dark:border-gray-800 dark:bg-slate-600 sidebar__header"
     >
       <div
         class="flex items-center gap-2 truncate"
@@ -346,14 +346,14 @@ exports[`Sidebar Component > should match snapshot 1`] = `
         class="flex select-none items-center gap-2"
       >
         <div
-          class="w-[26px] rounded-lg bg-slate-50 p-1 text-center text-xs text-slate-100 dark:bg-gray-900 dark:text-slate-200 hover:bg-slate-100 hover:text-slate-200 dark:hover:bg-gray-600 dark:hover:text-slate-50"
+          class="w-[26px] rounded-lg bg-slate-50 p-1 text-center text-xs text-slate-100 dark:bg-gray-900 dark:text-slate-200 hover:bg-slate-100 hover:text-slate-200 dark:hover:bg-gray-600 dark:hover:text-slate-50 sidebar__header-macro-item"
           role="button"
           tabindex="2"
         >
           1
         </div>
         <div
-          class="w-[26px] rounded-lg bg-slate-50 p-1 text-center text-xs text-slate-100 dark:bg-gray-900 dark:text-slate-200 hover:bg-slate-100 hover:text-slate-200 dark:hover:bg-gray-600 dark:hover:text-slate-50"
+          class="w-[26px] rounded-lg bg-slate-50 p-1 text-center text-xs text-slate-100 dark:bg-gray-900 dark:text-slate-200 hover:bg-slate-100 hover:text-slate-200 dark:hover:bg-gray-600 dark:hover:text-slate-50 sidebar__header-macro-item"
           role="button"
           tabindex="2"
         >
@@ -374,7 +374,7 @@ exports[`Sidebar Component > should match snapshot 1`] = `
             style="padding-left: 0px;"
           >
             <div
-              class="group/sidebar-item dark:hover:bg-charcoal-900 relative flex w-full cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 text-gray-700 hover:bg-gray-100 dark:text-gray-400 hover:pr-6"
+              class="group/sidebar-item dark:hover:bg-charcoal-900 relative flex w-full cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 text-gray-700 hover:bg-gray-100 dark:text-gray-400 hover:pr-6 sidebar__item"
               id="sidebar-item-1"
               tabindex="0"
             >
@@ -382,7 +382,7 @@ exports[`Sidebar Component > should match snapshot 1`] = `
                 class="flex max-w-full items-center gap-2"
               >
                 <div
-                  class="-m-2 -mr-1 h-full rounded-md py-2 pl-2 pr-1 hover:bg-gray-200"
+                  class="-m-2 -mr-1 h-full rounded-md py-2 pl-2 pr-1 hover:bg-gray-200 sidebar__item-caret"
                 >
                   <svg
                     class="min-w-4 -rotate-90 text-gray-700 dark:text-gray-400"
@@ -399,40 +399,40 @@ exports[`Sidebar Component > should match snapshot 1`] = `
                   </svg>
                 </div>
                 <div
-                  class="truncate text-sm leading-5"
+                  class="truncate text-sm leading-5 sidebar__item-title"
                 >
                   <span>
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                     N
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                     o
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                     d
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                     e
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                      
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                     1
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                   </span>
                 </div>
                 <div
-                  class="absolute top-1/2 flex -translate-y-1/2 items-center justify-center right-2 invisible text-gray-300 hover:text-gray-700 group-hover/sidebar-item:visible dark:text-gray-700 dark:hover:text-gray-50"
+                  class="absolute top-1/2 flex -translate-y-1/2 items-center justify-center right-2 invisible text-gray-300 hover:text-gray-700 group-hover/sidebar-item:visible dark:text-gray-700 dark:hover:text-gray-50 sidebar__item-pin"
                 >
                   <svg
                     fill="none"
@@ -458,7 +458,7 @@ exports[`Sidebar Component > should match snapshot 1`] = `
             style="padding-left: 0px;"
           >
             <div
-              class="group/sidebar-item dark:hover:bg-charcoal-900 relative flex w-full cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 text-gray-700 hover:bg-gray-100 dark:text-gray-400 hover:pr-6"
+              class="group/sidebar-item dark:hover:bg-charcoal-900 relative flex w-full cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 text-gray-700 hover:bg-gray-100 dark:text-gray-400 hover:pr-6 sidebar__item"
               id="sidebar-item-2"
               tabindex="0"
             >
@@ -466,10 +466,10 @@ exports[`Sidebar Component > should match snapshot 1`] = `
                 class="flex max-w-full items-center gap-2"
               >
                 <div
-                  class="-m-2 -mr-1 h-full rounded-md py-2 pl-2 pr-1 hover:bg-gray-200"
+                  class="-m-2 -mr-1 h-full rounded-md py-2 pl-2 pr-1 hover:bg-gray-200 sidebar__item-caret"
                 >
                   <svg
-                    class="min-w-4 -rotate-90 text-gray-300 dark:text-gray-700"
+                    class="min-w-4 -rotate-90 text-gray-300 dark:text-gray-700 sidebar__item-caret--no-children"
                     fill="currentcolor"
                     height="16"
                     viewBox="0 0 16 16"
@@ -483,40 +483,40 @@ exports[`Sidebar Component > should match snapshot 1`] = `
                   </svg>
                 </div>
                 <div
-                  class="truncate text-sm leading-5"
+                  class="truncate text-sm leading-5 sidebar__item-title"
                 >
                   <span>
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                     N
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                     o
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                     d
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                     e
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                      
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                     2
                     <span
-                      class="bg-gray-300 dark:bg-charcoal-800"
+                      class="bg-gray-300 dark:bg-charcoal-800 sidebar__item-title"
                     />
                   </span>
                 </div>
                 <div
-                  class="absolute top-1/2 flex -translate-y-1/2 items-center justify-center right-2 invisible text-gray-300 hover:text-gray-700 group-hover/sidebar-item:visible dark:text-gray-700 dark:hover:text-gray-50"
+                  class="absolute top-1/2 flex -translate-y-1/2 items-center justify-center right-2 invisible text-gray-300 hover:text-gray-700 group-hover/sidebar-item:visible dark:text-gray-700 dark:hover:text-gray-50 sidebar__item-pin"
                 >
                   <svg
                     fill="none"

--- a/src/ui/components/sidebar/sidebar.stories.tsx
+++ b/src/ui/components/sidebar/sidebar.stories.tsx
@@ -5,6 +5,7 @@ import mockedTree from './mocked_tree.json'
 import { Sidebar } from './sidebar.js'
 import { SidebarProvider } from './subcomponents/sidebar-provider/index.js'
 import type { SidebarNode } from './types.js'
+import { cn } from '#scalars/lib/utils.js'
 
 /**
  * The `Sidebar` component can be used within a page layout to provide a sidebar navigation.
@@ -46,6 +47,7 @@ import type { SidebarNode } from './types.js'
  * The `icon` and `expandedIcon` properties are optional and can be used to display an icon in the sidebar item.
  * This icons must be one of the [available icons](?path=/docs/powerhouse-iconography--readme)
  *
+ *
  * ## Sidebar Events
  *
  * The `Sidebar` component emits the following custom events:
@@ -79,7 +81,49 @@ import type { SidebarNode } from './types.js'
  *   };
  * }, []);
  * ```
+ *  ## Customization
+ * The sidebar can be customized using the `className` prop which accepts a string of Tailwind classes.
+ * Each class should follow the format `[&_.sidebar\\_\\_{element}]:{tailwind-classes}`.
+ *
+ * Base classes available for customization:
+ * - .sidebar__container: Main sidebar container
+ * - .sidebar__item: Individual sidebar item
+ * - .sidebar__item--active: Active sidebar item
+ * - .sidebar__item-title: Item title text
+ * - .sidebar__item-caret: Expand/collapse caret button
+ * - .sidebar__item-caret--no-children: Caret for items without children
+ * - .sidebar__item-pin: Pin button for items
+ * - .sidebar__item-pin--active: Active pin button
+ * - .sidebar__header: Sidebar header container
+ * - .sidebar__header-title: Header title text
+ * - .sidebar__header-macro-item: Macro item in header
+ * - .sidebar__pinning-area: Pinned items area
+ *
+ * ## Example Usage
+ *
+ *
+ * ```tsx
+ * import { Sidebar } from './sidebar'
+ *
+ * function MyCustomSidebar() {
+ *   return (
+ *     <Sidebar
+ *       className={String.raw`
+ *         [&_.sidebar\\_\\_item]:bg-blue-500
+ *         [&_.sidebar\\_\\_item]:text-white
+ *         [&_.sidebar\\_\\_item--active]:bg-green-500
+ *         [&_.sidebar\\_\\_item--active]:text-black
+ *         [&_.sidebar\\_\\_item-caret]:bg-yellow-500
+ *         [&_.sidebar\\_\\_item-pin]:fill-red-500
+ *         [&_.sidebar\\_\\_header]:bg-red-500
+ *         [&_.sidebar\\_\\_header-title]:text-white
+ *       `}
+ *     />
+ *   )
+ * }
+ * ```
  */
+
 const meta: Meta<typeof Sidebar> = {
   title: 'Navigation/Sidebar',
   component: Sidebar,
@@ -289,6 +333,88 @@ export const WithCustomTitleNavigation: Story = {
       <main className="flex h-svh w-full">
         <Sidebar
           className="sidebar"
+          {...args}
+          onActiveNodeChange={onActiveNodeChange}
+          activeNodeId={activeNode}
+          handleOnTitleClick={handleTitleClick}
+          sidebarTitle="Click me to go home!"
+        />
+        <div style={{ width: 'calc(100% - var(--sidebar-width))' }} className="flex-1 bg-gray-50 p-4 dark:bg-slate-800">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-50">Content Area</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">Active Node: {activeNode}</p>
+
+          <div className="mt-4">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-50">Navigation Log:</h2>
+            <div className="mt-2 overflow-y-auto rounded border p-2 bg-white dark:bg-slate-700">
+              {navigationLog.length === 0 ? (
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Click the sidebar title to see navigation events
+                </p>
+              ) : (
+                <ul className="text-sm text-gray-700 dark:text-gray-300">
+                  {navigationLog.map((log, index) => (
+                    <li key={index} className="py-1">
+                      {log}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      </main>
+    )
+  },
+}
+
+export const WithCustomStyles: Story = {
+  args: {
+    showStatusFilter: true,
+  },
+  render: function WithCustomTitleNavigationRender(args) {
+    const [activeNode, setActiveNode] = useState<string>('4281ab93-ef4f-4974-988d-7dad149a693d')
+    const [navigationLog, setNavigationLog] = useState<string[]>([])
+
+    const onActiveNodeChange = useCallback((node: SidebarNode) => {
+      setActiveNode(node.id)
+    }, [])
+
+    const handleTitleClick = useCallback(() => {
+      const timestamp = new Date().toLocaleTimeString()
+      setNavigationLog((prev) => [...prev, `Title clicked at ${timestamp} - Navigate to root/home`])
+    }, [])
+
+    return (
+      <main className="flex h-svh w-full">
+        <Sidebar
+          className={cn(
+            'sidebar',
+            String.raw`
+            [&_.sidebar\\_\\_item]:bg-blue-50
+            [&_.sidebar\\_\\_item]:border-blue-200
+            [&_.sidebar\\_\\_item]:text-blue-800
+            [&_.sidebar\\_\\_item--active]:bg-emerald-50
+            [&_.sidebar\\_\\_item--active]:border-emerald-300
+            [&_.sidebar\\_\\_item--active]:text-emerald-800
+            [&_.sidebar\\_\\_item-caret]:bg-amber-50
+            [&_.sidebar\\_\\_item-caret]:border-amber-200
+            [&_.sidebar\\_\\_item-caret]:text-amber-700
+            [&_.sidebar\\_\\_item-title]:text-slate-900
+
+            [&_.sidebar\\_\\_item-pin]:fill-rose-500
+            [&_.sidebar\\_\\_item-pin]:text-rose-600
+            [&_.sidebar\\_\\_item-pin--active]:fill-emerald-500
+            [&_.sidebar\\_\\_item-pin--active]:text-emerald-600
+            [&_.sidebar\\_\\_item-caret--no-children]:text-slate-400 dark:text-slate-500
+            [&_.sidebar\\_\\_header]:bg-slate-100
+            [&_.sidebar\\_\\_header]:text-slate-800
+            [&_.sidebar\\_\\_header-title]:text-slate-900
+            [&_.sidebar\\_\\_header-macro-item]:bg-indigo-50
+            [&_.sidebar\\_\\_header-macro-item]:text-indigo-800
+            [&_.sidebar\\_\\_pinning-area]:bg-amber-50
+            [&_.sidebar\\_\\_pinning-area]:text-amber-800
+             `
+          )}
           {...args}
           onActiveNodeChange={onActiveNodeChange}
           activeNodeId={activeNode}

--- a/src/ui/components/sidebar/sidebar.tsx
+++ b/src/ui/components/sidebar/sidebar.tsx
@@ -179,7 +179,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
       className={cn(
         'group peer relative flex h-svh max-h-screen flex-col bg-gray-50 shadow-lg transition-[width] duration-75 ease-linear dark:bg-slate-600',
         isResizing && 'transition-none',
-        className
+        className,
+        'sidebar__container'
       )}
     >
       {isSidebarOpen && (

--- a/src/ui/components/sidebar/subcomponents/sidebar-header.tsx
+++ b/src/ui/components/sidebar/subcomponents/sidebar-header.tsx
@@ -24,7 +24,11 @@ export const SidebarHeader: React.FC<SidebarHeaderProps> = ({
   const baseTitleClasses = 'truncate text-sm font-semibold text-gray-700 dark:text-gray-300'
   if (handleOnTitleClick) {
     titleElement = (
-      <button type="button" className={cn(baseTitleClasses, 'cursor-pointer')} onClick={handleOnTitleClick}>
+      <button
+        type="button"
+        className={cn(baseTitleClasses, 'cursor-pointer sidebar__header-title')}
+        onClick={handleOnTitleClick}
+      >
         {sidebarTitle}
       </button>
     )
@@ -33,7 +37,7 @@ export const SidebarHeader: React.FC<SidebarHeaderProps> = ({
   }
 
   return (
-    <header className="flex items-center justify-between gap-2 border-b border-gray-300 bg-gray-50 p-4 dark:border-gray-800 dark:bg-slate-600">
+    <header className="flex items-center justify-between gap-2 border-b border-gray-300 bg-gray-50 p-4 dark:border-gray-800 dark:bg-slate-600 sidebar__header">
       <div className="flex items-center gap-2 truncate">
         {sidebarIcon}
         {titleElement}
@@ -53,7 +57,8 @@ export const SidebarHeader: React.FC<SidebarHeaderProps> = ({
                   'w-[26px] rounded-lg bg-slate-50 p-1 text-center text-xs text-slate-100 dark:bg-gray-900 dark:text-slate-200',
                   !isDisabled &&
                     'hover:bg-slate-100 hover:text-slate-200 dark:hover:bg-gray-600 dark:hover:text-slate-50',
-                  isDisabled && 'cursor-not-allowed bg-gray-100 text-[#E2E4E7] dark:bg-[#252728] dark:text-slate-500'
+                  isDisabled && 'cursor-not-allowed bg-gray-100 text-[#E2E4E7] dark:bg-[#252728] dark:text-slate-500',
+                  'sidebar__header-macro-item'
                 )}
                 onClick={() => {
                   if (!isDisabled) {

--- a/src/ui/components/sidebar/subcomponents/sidebar-item.tsx
+++ b/src/ui/components/sidebar/subcomponents/sidebar-item.tsx
@@ -120,8 +120,7 @@ export const SidebarItem = ({
               pinnedMode &&
                 'after:absolute after:-top-2.5 after:left-[15px] after:h-4 after:w-px after:bg-gray-300 hover:bg-gray-50 first:group-first/sidebar-item-wrapper:after:hidden dark:hover:bg-slate-600',
               isActive &&
-                'font-medium text-gray-900 dark:text-gray-50 bg-gray-200 hover:bg-gray-200 dark:bg-charcoal-900 dark:hover:bg-charcoal-900',
-              isActive && 'sidebar__item--active',
+                'font-medium text-gray-900 dark:text-gray-50 bg-gray-200 hover:bg-gray-200 dark:bg-charcoal-900 dark:hover:bg-charcoal-900 sidebar__item--active',
               'sidebar__item'
             )}
             onClick={handleClick}

--- a/src/ui/components/sidebar/subcomponents/sidebar-item.tsx
+++ b/src/ui/components/sidebar/subcomponents/sidebar-item.tsx
@@ -139,9 +139,8 @@ export const SidebarItem = ({
                       'min-w-4',
                       node.isExpanded && node.children && node.children.length > 0 ? '' : '-rotate-90',
                       node.children === undefined || node.children.length === 0
-                        ? 'text-gray-300 dark:text-gray-700'
-                        : 'text-gray-700 dark:text-gray-400',
-                      (node.children === undefined || node.children.length === 0) && 'sidebar__item-caret--no-children'
+                        ? 'text-gray-300 dark:text-gray-700 sidebar__item-caret--no-children'
+                        : 'text-gray-700 dark:text-gray-400'
                     )}
                   />
                 </div>
@@ -172,10 +171,9 @@ export const SidebarItem = ({
                     'absolute top-1/2 flex -translate-y-1/2 items-center justify-center',
                     hasStatus ? 'right-8' : 'right-2',
                     isPinned
-                      ? 'text-gray-700 hover:text-blue-900 dark:text-gray-50 dark:hover:text-blue-900'
+                      ? 'text-gray-700 hover:text-blue-900 dark:text-gray-50 dark:hover:text-blue-900 sidebar__item-pin--active'
                       : 'invisible text-gray-300 hover:text-gray-700 group-hover/sidebar-item:visible dark:text-gray-700 dark:hover:text-gray-50',
-                    'sidebar__item-pin',
-                    isPinned && 'sidebar__item-pin--active'
+                    'sidebar__item-pin'
                   )}
                   onClick={handleTogglePin}
                 >

--- a/src/ui/components/sidebar/subcomponents/sidebar-item.tsx
+++ b/src/ui/components/sidebar/subcomponents/sidebar-item.tsx
@@ -119,14 +119,17 @@ export const SidebarItem = ({
               // line between pinned items
               pinnedMode &&
                 'after:absolute after:-top-2.5 after:left-[15px] after:h-4 after:w-px after:bg-gray-300 hover:bg-gray-50 first:group-first/sidebar-item-wrapper:after:hidden dark:hover:bg-slate-600',
-              isActive && 'font-medium text-gray-900 dark:text-gray-50'
+              isActive &&
+                'font-medium text-gray-900 dark:text-gray-50 bg-gray-200 hover:bg-gray-200 dark:bg-charcoal-900 dark:hover:bg-charcoal-900',
+              isActive && 'sidebar__item--active',
+              'sidebar__item'
             )}
             onClick={handleClick}
           >
             <div className="flex max-w-full items-center gap-2">
               {!pinnedMode && (
                 <div
-                  className="-m-2 -mr-1 h-full rounded-md py-2 pl-2 pr-1 hover:bg-gray-200"
+                  className="-m-2 -mr-1 h-full rounded-md py-2 pl-2 pr-1 hover:bg-gray-200 sidebar__item-caret"
                   onClick={handleCaretClick}
                 >
                   <CaretDown
@@ -137,7 +140,8 @@ export const SidebarItem = ({
                       node.isExpanded && node.children && node.children.length > 0 ? '' : '-rotate-90',
                       node.children === undefined || node.children.length === 0
                         ? 'text-gray-300 dark:text-gray-700'
-                        : 'text-gray-700 dark:text-gray-400'
+                        : 'text-gray-700 dark:text-gray-400',
+                      (node.children === undefined || node.children.length === 0) && 'sidebar__item-caret--no-children'
                     )}
                   />
                 </div>
@@ -159,7 +163,7 @@ export const SidebarItem = ({
                 searchTerm={searchTerm}
                 isSearchActive={isSearchActive}
                 pinnedMode={pinnedMode}
-                className={node.className}
+                className={cn(node.className, 'sidebar__item-title')}
               />
 
               {allowPinning && (
@@ -169,7 +173,9 @@ export const SidebarItem = ({
                     hasStatus ? 'right-8' : 'right-2',
                     isPinned
                       ? 'text-gray-700 hover:text-blue-900 dark:text-gray-50 dark:hover:text-blue-900'
-                      : 'invisible text-gray-300 hover:text-gray-700 group-hover/sidebar-item:visible dark:text-gray-700 dark:hover:text-gray-50'
+                      : 'invisible text-gray-300 hover:text-gray-700 group-hover/sidebar-item:visible dark:text-gray-700 dark:hover:text-gray-50',
+                    'sidebar__item-pin',
+                    isPinned && 'sidebar__item-pin--active'
                   )}
                   onClick={handleTogglePin}
                 >

--- a/src/ui/components/sidebar/subcomponents/sidebar-pinning-area.tsx
+++ b/src/ui/components/sidebar/subcomponents/sidebar-pinning-area.tsx
@@ -7,7 +7,7 @@ export const SidebarPinningArea = () => {
   const { pinnedNodePath, togglePin, activeNodeId, onActiveNodeChange } = useSidebar()
 
   return (
-    <div className="flex flex-col gap-1 border-b border-gray-300 bg-gray-100 px-2 pb-0.5 pt-2 dark:border-gray-800 dark:bg-slate-700">
+    <div className="flex flex-col gap-1 border-b border-gray-300 bg-gray-100 px-2 pb-0.5 pt-2 dark:border-gray-800 dark:bg-slate-700 sidebar__pinning-area">
       {pinnedNodePath.map((node, index) => (
         <SidebarItem
           key={node.id}


### PR DESCRIPTION
## Ticket
https://trello.com/c/2EjkcZti/1169-allow-sidebar-selected-node-to-have-a-bg-color

## Description
- Allow to pass custom classes to customize items from the sidebar

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)
<img width="1037" height="673" alt="image" src="https://github.com/user-attachments/assets/aba40063-afff-4241-9f2d-77355ad8e679" />

