### PR TITLE
fix(table): selected number header when the table is empty

### DIFF
--- a/src/table/components/header.tsx
+++ b/src/table/components/header.tsx
@@ -22,7 +22,7 @@ const TableHeader = ({ columns }: TableHeaderProps) => {
     api.selection.toggleSelectAll()
   }, [config.allowRowSelection, api.selection])
 
-  const isAllRowsSelected = selectedRowIndexes.length === api.getTotalRowsCount()
+  const isAllRowsSelected = api.getTotalRowsCount() !== 0 && selectedRowIndexes.length === api.getTotalRowsCount()
 
   const columnHeaders = useMemo(() => {
     return columns.map((column, columnIndex) => {


### PR DESCRIPTION
## Ticket
https://trello.com/c/GUb4sSsU

## Description
The # header was marked as selected when the table was empty. It is now fixed

## PR Author Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have performed a self-review of my own chromatic changes and everything is expected
- [ ] I have removed any unnecessary console messages and alerts
- [ ] I have removed any commented code
- [ ] I have checked that there are no dummy or unnecessary comments
- [ ] I have added new test cases (if it applies)
- [ ] I have not introduced any linting issues or warnings
