### PR TITLE
fix(table): saving non empty values was detected as empty

### DIFF
--- a/src/table/logic/table-api.ts
+++ b/src/table/logic/table-api.ts
@@ -226,12 +226,12 @@ class TableApi<TData> implements PrivateTableApiBase<TData> {
         }
 
         const formData = formRef.current?.getValues()
+        formRef.current?.reset()
         const value = formData?.[columnDef.field] as unknown
 
         if (isAddingRow) {
           // if the value is empty we need to prevent calling the onAdd callback
-          const isValueEmpty = typeof value !== 'boolean' || isEmpty(value)
-          if (isValueEmpty) {
+          if (isEmpty(value)) {
             this.selection.selectCell(selectedCell.row, selectedCell.column)
             return
           }


### PR DESCRIPTION
## Ticket
https://trello.com/c/GUb4sSsU

## Description
- When trying to save elements in the "adding row", it detected the values as empty and it didn't save/created new elements. Now, it is fixed
- After adding a value, the form is reset so next time the user have a cleared form

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings
