### PR TITLE
fix(scalars): fix amount when the description its to large

### DIFF
--- a/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
+++ b/src/scalars/components/amount-field/__snapshots__/amount-field.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`AmountField Component > should match snapshot 1`] = `
           type="hidden"
         />
         <div
-          class="relative flex items-center"
+          class="relative flex flex-1 items-center"
         >
           <div
             class="flex flex-col gap-2"
@@ -34,7 +34,7 @@ exports[`AmountField Component > should match snapshot 1`] = `
             >
               <input
                 aria-invalid="false"
-                class="flex w-full text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-gray-900 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-8 border-r-[0.5px] rounded-md outline-none focus-visible:ring-0 focus-visible:ring-offset-0 border-none h-[32px]"
+                class="flex text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-gray-900 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-8 w-full border-r-[0.5px] rounded-md outline-none focus-visible:ring-0 focus-visible:ring-offset-0 border-none h-[32px]"
                 data-cast="Number"
                 id=":r1:"
                 inputmode="numeric"

--- a/src/ui/components/data-entry/amount-input/__snapshots__/amount-input.test.tsx.snap
+++ b/src/ui/components/data-entry/amount-input/__snapshots__/amount-input.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`AmountField Component > should match snapshot 1`] = `
         type="hidden"
       />
       <div
-        class="relative flex items-center"
+        class="relative flex flex-1 items-center"
       >
         <div
           class="flex flex-col gap-2"
@@ -30,7 +30,7 @@ exports[`AmountField Component > should match snapshot 1`] = `
           >
             <input
               aria-invalid="false"
-              class="flex w-full text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-gray-900 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-8 border-r-[0.5px] rounded-md outline-none focus-visible:ring-0 focus-visible:ring-offset-0 border-none h-[32px]"
+              class="flex text-sm font-normal leading-5 text-gray-900 dark:text-gray-50 dark:border-charcoal-700 dark:bg-charcoal-900 border border-gray-300 bg-white px-3 py-2 font-sans placeholder:text-gray-500 dark:placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-gray-900 focus-visible:ring-offset-white dark:focus-visible:ring-charcoal-300 dark:focus-visible:ring-offset-charcoal-900 dark:focus:bg-charcoal-900 focus:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-50 disabled:text-gray-700 disabled:dark:border-charcoal-800 disabled:dark:bg-charcoal-900 disabled:dark:text-gray-300 pr-8 w-full border-r-[0.5px] rounded-md outline-none focus-visible:ring-0 focus-visible:ring-offset-0 border-none h-[32px]"
               data-cast="Number"
               id=":r0:"
               inputmode="numeric"

--- a/src/ui/components/data-entry/amount-input/amount-input.tsx
+++ b/src/ui/components/data-entry/amount-input/amount-input.tsx
@@ -158,7 +158,7 @@ const AmountInputController = forwardRef<HTMLInputElement, AmountInputProps>(
             {isShowSelect && currencyPosition === 'left' && (
               <div className="border-l-[1px] border-gray-300 h-full flex items-center" />
             )}
-            <div className={cn('relative flex items-center')}>
+            <div className={cn('relative flex flex-1 items-center')}>
               <NumberInput
                 name=""
                 step={step}
@@ -175,6 +175,7 @@ const AmountInputController = forwardRef<HTMLInputElement, AmountInputProps>(
                 enableStepCarets={enableStepCarets}
                 numericType={type === 'AmountCurrency' || type === 'AmountCrypto' ? 'BigInt' : 'Float'}
                 className={cn(
+                  'w-full',
                   currencyPosition === 'left' && 'rounded-l-none border-l-[0.5px]',
                   currencyPosition === 'right' && 'rounded-r-none border-r-[0.5px]',
                   isPercent && 'rounded-md pr-7',


### PR DESCRIPTION
## Ticket
- https://trello.com/c/iV03PjGR/757-9-amountfield

## Description
- Long text in the description or label can break the layout of the field, so it is recommended to allow text to wrap onto a second line or at least, the currency placeholder should be positioned correctly

## PR Author Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have performed a self-review of my own chromatic changes and everything is expected
- [ ] I have removed any unnecessary console messages and alerts
- [ ] I have removed any commented code
- [ ] I have checked that there are no dummy or unnecessary comments
- [ ] I have added new test cases (if it applies)
- [ ] I have not introduced any linting issues or warnings

## Screenshots (if apply)
<img width="989" height="359" alt="amount" src="https://github.com/user-attachments/assets/a5df2761-2def-4d65-a9ae-1d847d35aa36" />
<img width="1034" height="389" alt="image" src="https://github.com/user-attachments/assets/3e1f9235-0047-4419-a581-874cbf9771de" />
