### PR TITLE
fix(table): focus loss after edition exit

### DIFF
--- a/src/table/components/table-focus-trap.tsx
+++ b/src/table/components/table-focus-trap.tsx
@@ -8,7 +8,7 @@ const TableFocusTrap = ({ children }: { children: React.ReactNode }) => {
     state: { selectedCellIndex },
     api,
   } = useInternalTableState()
-  const ref = useRef<HTMLTableElement>(null)
+  const ref = useRef<HTMLDivElement>(null)
 
   useOnClickOutside(ref, (event) => {
     const { x, y } = (event.target as HTMLElement).getBoundingClientRect()
@@ -24,6 +24,7 @@ const TableFocusTrap = ({ children }: { children: React.ReactNode }) => {
 
     if (api.selection.haveSelectedCells()) {
       if (api.isEditing()) {
+        event.preventDefault()
         void api.exitCellEditMode(true)
         return // do not clear the cell selection
       }
@@ -31,10 +32,15 @@ const TableFocusTrap = ({ children }: { children: React.ReactNode }) => {
     }
   })
 
-  //   return children;
   return (
     <div ref={ref}>
-      <FocusTrap active={!!selectedCellIndex} focusTrapOptions={{ allowOutsideClick: true }}>
+      <FocusTrap
+        active={!!selectedCellIndex}
+        focusTrapOptions={{
+          allowOutsideClick: true,
+          escapeDeactivates: false,
+        }}
+      >
         {children}
       </FocusTrap>
     </div>

--- a/src/table/hooks/useGlobalTableKeyEvents.tsx
+++ b/src/table/hooks/useGlobalTableKeyEvents.tsx
@@ -73,9 +73,6 @@ const useGlobalTableKeyEvents = () => {
       }
     }
 
-    // TODO: check if adding a listener to the document for the cases when the focus trap is not active, or we will need to wire up the focus trap
-    // to get it here and activate it when the user press escape or exit the edit mode
-
     api.getHTMLTable()?.addEventListener('keydown', handleKeyDown)
     document.addEventListener('keydown', handleDeleteRows)
     return () => {

--- a/src/table/hooks/useGlobalTableKeyEvents.tsx
+++ b/src/table/hooks/useGlobalTableKeyEvents.tsx
@@ -73,6 +73,9 @@ const useGlobalTableKeyEvents = () => {
       }
     }
 
+    // TODO: check if adding a listener to the document for the cases when the focus trap is not active, or we will need to wire up the focus trap
+    // to get it here and activate it when the user press escape or exit the edit mode
+
     api.getHTMLTable()?.addEventListener('keydown', handleKeyDown)
     document.addEventListener('keydown', handleDeleteRows)
     return () => {

--- a/src/table/logic/selection-manager.ts
+++ b/src/table/logic/selection-manager.ts
@@ -134,6 +134,13 @@ class SelectionManager<TData> implements TableSelectionManager {
       type: 'SELECT_CELL',
       payload: { row: rowIndex, column: columnIndex },
     })
+
+    const td = this.api
+      .getHTMLTable()
+      ?.querySelector(`tr:nth-child(${rowIndex + 1}) td:nth-child(${columnIndex + 2})`) as HTMLTableCellElement | null
+    if (td) {
+      td.focus()
+    }
   }
 
   /**

--- a/src/table/logic/table-api.ts
+++ b/src/table/logic/table-api.ts
@@ -271,10 +271,7 @@ class TableApi<TData> implements PrivateTableApiBase<TData> {
         formRef.current?.reset()
       }
 
-      this._getState().dispatch?.({
-        type: 'SELECT_CELL',
-        payload: { row: selectedCell.row, column: selectedCell.column },
-      })
+      this.selection.selectCell(selectedCell.row, selectedCell.column)
     }
   }
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/GUb4sSsU

## Description
- Fix focus loss after the edition ends or the user clicks outside the table while editing

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

