### PR TITLE
fix(select): maintain selection when re-selecting the same option

### DIFF
--- a/src/scalars/components/fragments/select-field/select-field.test.tsx
+++ b/src/scalars/components/fragments/select-field/select-field.test.tsx
@@ -62,6 +62,25 @@ describe('SelectField Component', () => {
     expect(onChangeMock).not.toHaveBeenCalled()
   })
 
+  it('should maintain selection when re-selecting the same option', async () => {
+    const onChangeMock = vi.fn()
+    const user = userEvent.setup()
+
+    renderWithForm(<SelectField name="select" options={defaultOptions} onChange={onChangeMock} />)
+
+    await user.click(screen.getByRole('combobox'))
+    await user.click(screen.getByText('Option 1'))
+
+    expect(onChangeMock).toHaveBeenCalledWith('1')
+    expect(screen.getByText('Option 1')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('combobox'))
+    await user.click(screen.getByRole('option', { name: 'Option 1' }))
+
+    expect(screen.getByText('Option 1')).toBeInTheDocument()
+    expect(onChangeMock).toHaveBeenCalledTimes(1)
+  })
+
   // Search Functionality Tests
   it('should show search input when searchable is true', async () => {
     const user = userEvent.setup()

--- a/src/ui/components/data-entry/select/select.test.tsx
+++ b/src/ui/components/data-entry/select/select.test.tsx
@@ -61,6 +61,25 @@ describe('Select Component', () => {
     expect(onChangeMock).not.toHaveBeenCalled()
   })
 
+  it('should maintain selection when re-selecting the same option', async () => {
+    const onChangeMock = vi.fn()
+    const user = userEvent.setup()
+
+    render(<Select name="select" options={defaultOptions} onChange={onChangeMock} />)
+
+    await user.click(screen.getByRole('combobox'))
+    await user.click(screen.getByText('Option 1'))
+
+    expect(onChangeMock).toHaveBeenCalledWith('1')
+    expect(screen.getByText('Option 1')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('combobox'))
+    await user.click(screen.getByRole('option', { name: 'Option 1' }))
+
+    expect(screen.getByText('Option 1')).toBeInTheDocument()
+    expect(onChangeMock).toHaveBeenCalledTimes(1)
+  })
+
   // Search Functionality Tests
   it('should show search input when searchable is true', async () => {
     const user = userEvent.setup()

--- a/src/ui/components/data-entry/select/select.tsx
+++ b/src/ui/components/data-entry/select/select.tsx
@@ -65,6 +65,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       useSelect({
         options: allOptions,
         multiple,
+        searchable,
         defaultValue,
         value,
         onChange,

--- a/src/ui/components/data-entry/select/use-select.ts
+++ b/src/ui/components/data-entry/select/use-select.ts
@@ -4,12 +4,20 @@ import type { SelectProps } from './types.js'
 interface UseSelectProps {
   options?: SelectProps['options']
   multiple?: boolean
+  searchable?: boolean
   defaultValue?: string | string[]
   value?: string | string[]
   onChange?: (value: string | string[]) => void
 }
 
-export function useSelect({ options = [], multiple = false, defaultValue, value, onChange }: UseSelectProps) {
+export function useSelect({
+  options = [],
+  multiple = false,
+  searchable = false,
+  defaultValue,
+  value,
+  onChange,
+}: UseSelectProps) {
   const isInternalChange = useRef(false)
   const commandListRef = useRef<HTMLDivElement>(null)
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
@@ -48,15 +56,19 @@ export function useSelect({ options = [], multiple = false, defaultValue, value,
           ? selectedValues.filter((v) => v !== optionValue)
           : [...selectedValues, optionValue]
       } else {
-        newValues = selectedValues[0] === optionValue ? [] : [optionValue]
+        if (selectedValues[0] === optionValue && !searchable) {
+          setIsPopoverOpen(false)
+          return
+        }
 
+        newValues = selectedValues[0] === optionValue ? [] : [optionValue]
         setIsPopoverOpen(false)
       }
 
       setSelectedValues(newValues)
       onChange?.(multiple ? newValues : (newValues[0] ?? ''))
     },
-    [multiple, selectedValues, onChange]
+    [multiple, searchable, selectedValues, onChange]
   )
 
   const handleClear = useCallback(() => {


### PR DESCRIPTION
## Ticket
https://trello.com/c/1LBnPVC1/1184-drop-down-components-across

## Description
- Maintain selection when re-selecting the same option in the Select component when !multiple && !searchable

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings