### PR TITLE
feat(table): editing events

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -33,6 +33,7 @@ const preview: Preview = {
                 'Deletion',
                 'Sorting',
                 'Actions',
+                'Events',
                 'API',
                 'Keyboard Shortcuts',
               ],

--- a/src/table/components/table-provider/table-provider.tsx
+++ b/src/table/components/table-provider/table-provider.tsx
@@ -10,7 +10,7 @@ interface TableContextValue<T extends DataType = DataType> {
   config: ObjectSetTableConfig<T>
   state: TableState<T>
   api: PrivateTableApiBase<T>
-  publicApi: TableApiBase
+  publicApi: TableApiBase<T>
 }
 
 const TableContext = createContext<TableContextValue<DataType> | null>(null)
@@ -71,6 +71,11 @@ const TableProvider = <T extends DataType = DataType>({ children, config, tableR
 
     return [internalApi, publicApi]
   }, [config.apiRef, tableRef])
+
+  // Update event manager element reference when table ref becomes available
+  useEffect(() => {
+    api.updateEventManagerElement()
+  }, [api])
 
   return (
     <TableContext.Provider

--- a/src/table/docs/events.mdx
+++ b/src/table/docs/events.mdx
@@ -1,0 +1,157 @@
+import { Meta, Source, Canvas, Controls } from '@storybook/blocks'
+
+<Meta title="Data Display/Object Set Table/Docs/Events" />
+
+## Events
+
+The Table dispatches DOM events for all operations. Events are type-safe and include detailed context.
+
+### Available Events
+
+| Event | When | Key Payload Fields |
+|-------|------|-------------------|
+| `table:editing:start` | Cell enters edit mode | `currentValue`, `isAddingRow` |
+| `table:editing:save` | Cell edit saved | `oldValue`, `newValue`, `isAddingRow` |
+| `table:editing:exit` | Exit edit mode | `saved` (boolean), `finalValue` |
+| `table:editing:validationError` | Validation fails | `errors[]`, `value` |
+| `table:editing:validationSuccess` | Validation passes | `value` |
+| `table:editing:validationErrorChange` | Error state changes | `previousErrors[]`, `currentErrors[]` |
+
+**Common Payload Fields (all events):**
+- `timestamp: Date` - When event occurred
+- `rowIndex: number` - Row position (0-based)  
+- `cell: { row, column }` - Cell coordinates
+- `columnDef: ColumnDef<TData>` - Column configuration
+- `rowData?: TData` - Complete row data (optional)
+
+---
+
+## Usage
+
+### Basic Setup
+
+```tsx
+import { useEffect, useRef } from 'react'
+import type { TableApiBase, TableEventMap } from '@powerhousedao/document-engineering'
+
+const MyComponent = () => {
+  const apiRef = useRef<TableApiBase<MyDataType>>(null)
+
+  useEffect(() => {
+    const tableElement = apiRef.current?.getHTMLTable()
+    if (!tableElement) return
+
+    const handleSave = ((event: CustomEvent<TableEventMap<MyDataType>['table:editing:save']>) => {
+      const { columnDef, oldValue, newValue } = event.detail
+      console.log(`${columnDef.field}: ${oldValue} → ${newValue}`)
+    }) as EventListener
+
+    tableElement.addEventListener('table:editing:save', handleSave)
+    return () => tableElement.removeEventListener('table:editing:save', handleSave)
+  }, [])
+
+  return <ObjectSetTable data={data} columns={columns} apiRef={apiRef} />
+}
+```
+
+### Multiple Events
+
+```tsx
+useEffect(() => {
+  const tableElement = apiRef.current?.getHTMLTable()
+  if (!tableElement) return
+
+  const handlers = {
+    'table:editing:start': (e: CustomEvent) => {
+      const { columnDef, isAddingRow } = e.detail
+      setEditingState({ field: columnDef.field, isNew: isAddingRow })
+    },
+    'table:editing:save': (e: CustomEvent) => {
+      const { columnDef, newValue } = e.detail
+      syncToAPI(columnDef.field, newValue)
+    },
+    'table:editing:validationError': (e: CustomEvent) => {
+      const { cell, errors } = e.detail
+      showErrors(`${cell.row}-${cell.column}`, errors)
+    }
+  } as const
+
+  // Register all
+  Object.entries(handlers).forEach(([event, handler]) => {
+    tableElement.addEventListener(event, handler as EventListener)
+  })
+
+  // Cleanup all
+  return () => {
+    Object.entries(handlers).forEach(([event, handler]) => {
+      tableElement.removeEventListener(event, handler as EventListener)
+    })
+  }
+}, [])
+```
+
+---
+
+## Common Patterns
+
+### Data Sync
+```tsx
+const handleSave = ((event: CustomEvent) => {
+  const { rowData, newValue, columnDef } = event.detail
+  updateAPI(rowData.id, columnDef.field, newValue)
+}) as EventListener
+```
+
+### Validation UI
+```tsx
+const [errors, setErrors] = useState<Record<string, string[]>>({})
+
+const handleValidationChange = ((event: CustomEvent) => {
+  const { cell, currentErrors } = event.detail
+  const key = `${cell.row}-${cell.column}`
+  setErrors(prev => ({ ...prev, [key]: currentErrors }))
+}) as EventListener
+```
+
+### Activity Logging
+```tsx
+const handleAnyEdit = ((event: CustomEvent) => {
+  const { columnDef, timestamp } = event.detail
+  logActivity(`Edited ${columnDef.field} at ${timestamp}`)
+}) as EventListener
+```
+
+---
+
+## Event Types
+
+All events extend base interfaces and include validation context when relevant:
+
+```tsx
+interface BaseTableEvent {
+  timestamp: Date
+}
+
+interface BaseCellEvent<TData> extends BaseTableEvent {
+  rowIndex: number
+  cell: { row: number; column: number }
+  columnDef: ColumnDef<TData>
+  rowData?: TData
+}
+
+interface ValidationContext {
+  hasErrors: boolean
+  errorCount: number
+  validationRules?: string[]
+}
+```
+
+**Future Events:** The system is extensible for row operations, column operations, and table-level events.
+
+---
+
+## Related Docs
+
+- [API Reference](?path=/docs/data-display-object-set-table-docs-api--readme): Full API documentation
+- [Editing](?path=/docs/data-display-object-set-table-docs-editing--readme): Cell editing and validation
+- [Events Example](?path=/story/data-display-object-set-table-examples-events--default): Live event logging demo

--- a/src/table/events/index.ts
+++ b/src/table/events/index.ts
@@ -1,0 +1,17 @@
+export { TableEventManager } from './table-event-manager.js'
+export type {
+  BaseTableEvent,
+  BaseRowEvent,
+  BaseCellEvent,
+  BaseColumnEvent,
+  ValidationContext,
+  EditingStartEvent,
+  EditingSaveEvent,
+  EditingExitEvent,
+  ValidationErrorEvent,
+  ValidationSuccessEvent,
+  ValidationErrorChangeEvent,
+  TableEventPayload,
+  TableEventMap,
+  TableEventListener,
+} from './types.js'

--- a/src/table/events/table-event-manager.ts
+++ b/src/table/events/table-event-manager.ts
@@ -1,0 +1,146 @@
+import type {
+  EditingExitEvent,
+  EditingSaveEvent,
+  EditingStartEvent,
+  TableEventMap,
+  ValidationErrorChangeEvent,
+  ValidationErrorEvent,
+  ValidationSuccessEvent,
+} from './types.js'
+
+/**
+ * TableEventManager handles dispatching of custom events for table operations.
+ * Provides type-safe event triggering methods and centralized event management.
+ */
+export class TableEventManager<TData = unknown> {
+  private element: HTMLElement | Document | null
+
+  constructor(element: HTMLElement | Document | null = null) {
+    this.element = element ?? document
+  }
+
+  /**
+   * Updates the element reference for event dispatching
+   */
+  setElement(element: HTMLElement | Document | null): void {
+    this.element = element ?? document
+  }
+
+  private printWarning(message: string): void {
+    if (process.env.NODE_ENV === 'development') {
+      // This is a warning that is only shown in development mode for better DX
+      // eslint-disable-next-line no-console
+      console.warn(message)
+    }
+  }
+
+  /**
+   * Generic method to trigger any table event
+   */
+  private triggerEvent<K extends keyof TableEventMap<TData>>(eventType: K, payload: TableEventMap<TData>[K]): void {
+    if (!this.element) {
+      this.printWarning(`TableEventManager: Cannot dispatch event '${eventType}' - no element reference`)
+      return
+    }
+
+    const event = new CustomEvent(eventType, {
+      detail: payload,
+      bubbles: true,
+      cancelable: false,
+    })
+
+    this.element.dispatchEvent(event)
+  }
+
+  /**
+   * Triggers when a cell enters edit mode
+   */
+  triggerEditingStart(payload: Omit<EditingStartEvent<TData>, 'timestamp'>): void {
+    this.triggerEvent('table:editing:start', {
+      ...payload,
+      timestamp: new Date(),
+    })
+  }
+
+  /**
+   * Triggers when a cell edit is successfully saved
+   */
+  triggerEditingSave(payload: Omit<EditingSaveEvent<TData>, 'timestamp'>): void {
+    this.triggerEvent('table:editing:save', {
+      ...payload,
+      timestamp: new Date(),
+    })
+  }
+
+  /**
+   * Triggers when exiting edit mode (regardless of save/cancel)
+   */
+  triggerEditingExit(payload: Omit<EditingExitEvent<TData>, 'timestamp'>): void {
+    this.triggerEvent('table:editing:exit', {
+      ...payload,
+      timestamp: new Date(),
+    })
+  }
+
+  /**
+   * Triggers when validation fails
+   */
+  triggerValidationError(payload: Omit<ValidationErrorEvent<TData>, 'timestamp'>): void {
+    this.triggerEvent('table:editing:validationError', {
+      ...payload,
+      timestamp: new Date(),
+    })
+  }
+
+  /**
+   * Triggers when validation succeeds
+   */
+  triggerValidationSuccess(payload: Omit<ValidationSuccessEvent<TData>, 'timestamp'>): void {
+    this.triggerEvent('table:editing:validationSuccess', {
+      ...payload,
+      timestamp: new Date(),
+    })
+  }
+
+  /**
+   * Triggers when validation error state changes
+   */
+  triggerValidationErrorChange(payload: Omit<ValidationErrorChangeEvent<TData>, 'timestamp'>): void {
+    this.triggerEvent('table:editing:validationErrorChange', {
+      ...payload,
+      timestamp: new Date(),
+    })
+  }
+
+  /**
+   * Add an event listener for a specific table event
+   */
+  addEventListener<K extends keyof TableEventMap<TData>>(
+    eventType: K,
+    listener: (event: CustomEvent<TableEventMap<TData>[K]>) => void,
+    options?: AddEventListenerOptions
+  ): void {
+    if (!this.element) {
+      this.printWarning(`TableEventManager: Cannot add listener for '${eventType}' - no element reference`)
+      return
+    }
+
+    this.element.addEventListener(eventType, listener as EventListener, options)
+  }
+
+  /**
+   * Remove an event listener for a specific table event
+   */
+  removeEventListener<K extends keyof TableEventMap<TData>>(
+    eventType: K,
+    listener: (event: CustomEvent<TableEventMap<TData>[K]>) => void,
+    options?: EventListenerOptions
+  ): void {
+    if (!this.element) {
+      this.printWarning(`TableEventManager: Cannot remove listener for '${eventType}' - no element reference`)
+      return
+    }
+
+    this.element.removeEventListener(eventType, listener as EventListener, options)
+  }
+}

--- a/src/table/events/types.ts
+++ b/src/table/events/types.ts
@@ -1,0 +1,208 @@
+import type { ColumnDef } from '../table/types.js'
+
+/**
+ * Base interface for all table events (most generic level)
+ */
+export interface BaseTableEvent {
+  /**
+   * Timestamp when the event occurred
+   */
+  timestamp: Date
+}
+
+/**
+ * Base interface for row-level table events
+ */
+export interface BaseRowEvent<TData = unknown> extends BaseTableEvent {
+  /**
+   * The row index where the event occurred
+   */
+  rowIndex: number
+  /**
+   * The complete row data (optional for events that don't need full row context)
+   */
+  rowData?: TData
+}
+
+/**
+ * Base interface for cell-level table events
+ */
+export interface BaseCellEvent<TData = unknown> extends BaseRowEvent<TData> {
+  /**
+   * The cell coordinates where the event occurred
+   */
+  cell: {
+    row: number
+    column: number
+  }
+  /**
+   * The column definition for the cell
+   */
+  columnDef: ColumnDef<TData>
+}
+
+/**
+ * Base interface for column-level table events
+ */
+export interface BaseColumnEvent extends BaseTableEvent {
+  /**
+   * The column index where the event occurred
+   */
+  columnIndex: number
+}
+
+/**
+ * Validation context for editing and validation events
+ */
+export interface ValidationContext {
+  /**
+   * Whether there are currently validation errors
+   */
+  hasErrors: boolean
+  /**
+   * Number of current validation errors
+   */
+  errorCount: number
+  /**
+   * Applied validation rules (optional)
+   */
+  validationRules?: string[]
+}
+
+/**
+ * Event triggered when a cell enters edit mode
+ */
+export interface EditingStartEvent<TData = unknown> extends BaseCellEvent<TData> {
+  /**
+   * The current value in the cell before editing
+   */
+  currentValue: unknown
+  /**
+   * Whether this is a new row being added
+   */
+  isAddingRow: boolean
+  /**
+   * Validation context (optional)
+   */
+  validationContext?: ValidationContext
+}
+
+/**
+ * Event triggered when a cell edit is successfully saved
+ */
+export interface EditingSaveEvent<TData = unknown> extends BaseCellEvent<TData> {
+  /**
+   * The old value before the edit
+   */
+  oldValue: unknown
+  /**
+   * The new value after the edit
+   */
+  newValue: unknown
+  /**
+   * Whether this was a new row being added
+   */
+  isAddingRow: boolean
+  /**
+   * Validation context (optional)
+   */
+  validationContext?: ValidationContext
+}
+
+/**
+ * Event triggered when exiting edit mode (regardless of save/cancel)
+ */
+export interface EditingExitEvent<TData = unknown> extends BaseCellEvent<TData> {
+  /**
+   * Whether the edit was saved or cancelled
+   */
+  saved: boolean
+  /**
+   * The final value (may be unchanged if cancelled)
+   */
+  finalValue: unknown
+}
+
+/**
+ * Event triggered when validation fails
+ */
+export interface ValidationErrorEvent<TData = unknown> extends BaseCellEvent<TData> {
+  /**
+   * Array of validation error messages
+   */
+  errors: string[]
+  /**
+   * The value that failed validation
+   */
+  value: unknown
+  /**
+   * Validation context
+   */
+  validationContext: ValidationContext
+}
+
+/**
+ * Event triggered when validation succeeds
+ */
+export interface ValidationSuccessEvent<TData = unknown> extends BaseCellEvent<TData> {
+  /**
+   * The value that passed validation
+   */
+  value: unknown
+  /**
+   * Validation context
+   */
+  validationContext: ValidationContext
+}
+
+/**
+ * Event triggered when validation error state changes
+ */
+export interface ValidationErrorChangeEvent<TData = unknown> extends BaseCellEvent<TData> {
+  /**
+   * Previous error state
+   */
+  previousErrors: string[]
+  /**
+   * Current error state
+   */
+  currentErrors: string[]
+  /**
+   * The value being validated
+   */
+  value: unknown
+  /**
+   * Validation context
+   */
+  validationContext: ValidationContext
+}
+
+/**
+ * Union type of all possible table event payloads
+ */
+export type TableEventPayload<TData = unknown> =
+  | EditingStartEvent<TData>
+  | EditingSaveEvent<TData>
+  | EditingExitEvent<TData>
+  | ValidationErrorEvent<TData>
+  | ValidationSuccessEvent<TData>
+  | ValidationErrorChangeEvent<TData>
+
+/**
+ * Mapping of event names to their payload types
+ */
+export interface TableEventMap<TData = unknown> {
+  'table:editing:start': EditingStartEvent<TData>
+  'table:editing:save': EditingSaveEvent<TData>
+  'table:editing:exit': EditingExitEvent<TData>
+  'table:editing:validationError': ValidationErrorEvent<TData>
+  'table:editing:validationSuccess': ValidationSuccessEvent<TData>
+  'table:editing:validationErrorChange': ValidationErrorChangeEvent<TData>
+}
+
+/**
+ * Generic event listener type
+ */
+export type TableEventListener<TData = unknown, T extends keyof TableEventMap<TData> = keyof TableEventMap<TData>> = (
+  event: CustomEvent<TableEventMap<TData>[T]>
+) => void

--- a/src/table/examples/api-usage/api-usage.tsx
+++ b/src/table/examples/api-usage/api-usage.tsx
@@ -9,7 +9,7 @@ import { Form } from '../../../scalars/components/form/form.js'
 import { NumberField } from '../../../scalars/components/number-field/number-field.js'
 
 const ApiUsageExample = () => {
-  const apiRef = useRef<TableApiBase>(null)
+  const apiRef = useRef<TableApiBase<MockedPerson>>(null)
   const columns = useMemo<Array<ColumnDef<MockedPerson>>>(
     () => [
       { field: 'firstName', title: 'Name', sortable: true },

--- a/src/table/examples/events/event-log-card.tsx
+++ b/src/table/examples/events/event-log-card.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+import type { EventLog } from './events.js'
+
+interface EventLogCardProps {
+  eventLogs: EventLog[]
+  clearEventLogs: () => void
+}
+
+// Background effect implemented: new events show with blue background and pulse animation
+
+export const EventLogCard = ({ eventLogs, clearEventLogs }: EventLogCardProps) => {
+  const [newEventIds, setNewEventIds] = useState<Set<string>>(new Set())
+
+  // Track when new events are added
+  useEffect(() => {
+    if (eventLogs.length === 0) {
+      setNewEventIds(new Set())
+      return
+    }
+
+    // Get the most recent event (first in array since new events are prepended)
+    const latestEvent = eventLogs[0]
+    setNewEventIds((prev) => new Set([...prev, latestEvent.id]))
+
+    // Remove the "new" status after animation completes
+    const timer = setTimeout(() => {
+      setNewEventIds((prev) => {
+        const updated = new Set(prev)
+        updated.delete(latestEvent.id)
+        return updated
+      })
+    }, 2000) // Remove effect after 2 seconds
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [eventLogs])
+
+  return (
+    <div className="w-96 max-h-[650px] flex flex-col">
+      <div className="sticky top-4 flex flex-col h-full">
+        <div className="bg-white border border-gray-300 rounded-lg shadow-sm flex flex-col h-full">
+          <div className="p-4 border-b border-gray-200 flex justify-between items-center flex-shrink-0">
+            <h3 className="text-md font-semibold text-gray-900">Event Logs</h3>
+            <button
+              onClick={clearEventLogs}
+              className="text-xs text-gray-500 hover:text-gray-700 px-2 py-1 rounded border border-gray-300 hover:bg-gray-50"
+            >
+              Clear
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            {eventLogs.length === 0 ? (
+              <div className="p-4 text-center text-gray-500 text-sm">
+                No events logged yet. Interact with the table to see events.
+              </div>
+            ) : (
+              <div className="p-2 space-y-2">
+                {eventLogs.map((event) => {
+                  const isNew = newEventIds.has(event.id)
+                  return (
+                    <div
+                      key={event.id}
+                      className={`p-3 rounded-md border text-xs transition-all duration-500 ease-out ${isNew ? 'bg-blue-100 border-blue-300 animate-pulse' : 'bg-gray-50 border-gray-200'}`}
+                    >
+                      <div className="flex justify-between items-start mb-1">
+                        <span className="font-semibold text-blue-600">{event.type}</span>
+                        <span className="text-gray-500">{event.timestamp}</span>
+                      </div>
+                      <div className="text-gray-700 mb-2">{event.details}</div>
+                      {(event.data as Record<string, unknown> | undefined) && (
+                        <details className="text-gray-600">
+                          <summary className="cursor-pointer text-xs text-gray-500 hover:text-gray-700">
+                            View data
+                          </summary>
+                          <pre className="mt-1 p-2 bg-white rounded border text-xs overflow-x-auto">
+                            {JSON.stringify(event.data as Record<string, unknown>, null, 2)}
+                          </pre>
+                        </details>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/table/examples/events/events.stories.tsx
+++ b/src/table/examples/events/events.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { EventsExample } from './events.js'
+
+const meta = {
+  title: 'Data Display/Object Set Table/Examples/Events',
+  component: EventsExample,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    chromatic: { disableSnapshot: true },
+  },
+} satisfies Meta<typeof EventsExample>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {},
+}

--- a/src/table/examples/events/events.tsx
+++ b/src/table/examples/events/events.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { ObjectSetTable } from '../../table/object-set-table.js'
+import { mockData, type MockedPerson } from '../../table/mock-data.js'
+import type { TableApiBase } from '../../logic/types.js'
+import { cn } from '../../../scalars/lib/utils.js'
+import type { CellContext, ColumnDef } from '../../table/types.js'
+import { EventLogCard } from './event-log-card.js'
+import type { TableEventMap } from '../../events/index.js'
+
+export interface EventLog {
+  id: string
+  timestamp: string
+  type: string
+  details: string
+  data?: unknown
+}
+
+const EventsExample = () => {
+  const apiRef = useRef<TableApiBase<MockedPerson>>(null)
+  const [eventLogs, setEventLogs] = useState<EventLog[]>([])
+  const [data, setData] = useState<MockedPerson[]>(mockData)
+
+  const addEventLog = (type: string, details: string, data?: unknown) => {
+    const newEvent: EventLog = {
+      id: Date.now().toString(),
+      timestamp: new Date().toLocaleTimeString(),
+      type,
+      details,
+      data,
+    }
+    setEventLogs((prev) => [newEvent, ...prev])
+  }
+
+  const clearEventLogs = () => {
+    setEventLogs([])
+  }
+
+  // Set up event listeners for table editing events
+  useEffect(() => {
+    const api = apiRef.current
+    if (!api) return
+
+    const handleEditingStart = ((event: CustomEvent<TableEventMap<MockedPerson>['table:editing:start']>) => {
+      const { columnDef, isAddingRow } = event.detail
+      addEventLog(
+        'editing:start',
+        `Started editing ${columnDef.field} at row ${event.detail.cell.row}, column ${event.detail.cell.column}${isAddingRow ? ' (new row)' : ''}`,
+        event.detail
+      )
+    }) as EventListener
+
+    const handleEditingSave = ((event: CustomEvent<TableEventMap<MockedPerson>['table:editing:save']>) => {
+      const { columnDef, oldValue, newValue, isAddingRow } = event.detail
+      addEventLog(
+        'editing:save',
+        `Saved ${columnDef.field}: ${String(oldValue)} → ${String(newValue)}${isAddingRow ? ' (new row)' : ''}`,
+        event.detail
+      )
+    }) as EventListener
+
+    const handleEditingExit = ((event: CustomEvent<TableEventMap<MockedPerson>['table:editing:exit']>) => {
+      const { columnDef, saved } = event.detail
+      addEventLog('editing:exit', `Exited editing ${columnDef.field} (${saved ? 'saved' : 'cancelled'})`, event.detail)
+    }) as EventListener
+
+    const handleValidationError = ((
+      event: CustomEvent<TableEventMap<MockedPerson>['table:editing:validationError']>
+    ) => {
+      const { columnDef, errors } = event.detail
+      addEventLog(
+        'editing:validationError',
+        `Validation failed for ${columnDef.field}: ${errors.join(', ')}`,
+        event.detail
+      )
+    }) as EventListener
+
+    const handleValidationSuccess = ((
+      event: CustomEvent<TableEventMap<MockedPerson>['table:editing:validationSuccess']>
+    ) => {
+      const { columnDef } = event.detail
+      addEventLog('editing:validationSuccess', `Validation passed for ${columnDef.field}`, event.detail)
+    }) as EventListener
+
+    const handleValidationErrorChange = ((
+      event: CustomEvent<TableEventMap<MockedPerson>['table:editing:validationErrorChange']>
+    ) => {
+      const { columnDef, previousErrors, currentErrors } = event.detail
+      const hasErrors = currentErrors.length > 0
+      const hadErrors = previousErrors.length > 0
+      let details = ''
+      if (!hadErrors && hasErrors) {
+        details = `Validation errors appeared for ${columnDef.field}: ${currentErrors.join(', ')}`
+      } else if (hadErrors && !hasErrors) {
+        details = `Validation errors cleared for ${columnDef.field}`
+      } else if (hadErrors && hasErrors) {
+        details = `Validation errors changed for ${columnDef.field}: ${currentErrors.join(', ')}`
+      }
+      addEventLog('editing:validationErrorChange', details, event.detail)
+    }) as EventListener
+
+    const tableElement = api.getHTMLTable()!
+    tableElement.addEventListener('table:editing:start', handleEditingStart)
+    tableElement.addEventListener('table:editing:save', handleEditingSave)
+    tableElement.addEventListener('table:editing:exit', handleEditingExit)
+    tableElement.addEventListener('table:editing:validationError', handleValidationError)
+    tableElement.addEventListener('table:editing:validationSuccess', handleValidationSuccess)
+    tableElement.addEventListener('table:editing:validationErrorChange', handleValidationErrorChange)
+
+    return () => {
+      // Cleanup event listeners
+      tableElement.removeEventListener('table:editing:start', handleEditingStart)
+      tableElement.removeEventListener('table:editing:save', handleEditingSave)
+      tableElement.removeEventListener('table:editing:exit', handleEditingExit)
+      tableElement.removeEventListener('table:editing:validationError', handleValidationError)
+      tableElement.removeEventListener('table:editing:validationSuccess', handleValidationSuccess)
+      tableElement.removeEventListener('table:editing:validationErrorChange', handleValidationErrorChange)
+    }
+  }, [])
+
+  const handleAdd = (newRowData: Record<string, unknown>) => {
+    addEventLog('onAdd', `New row added with data: ${JSON.stringify(newRowData)}`, newRowData)
+
+    // Simulate adding the new row to the data
+    const newRow: MockedPerson = {
+      id: Math.random().toString(),
+      firstName: (newRowData.firstName as string) || 'New Person',
+      walletAddress: (newRowData.walletAddress as string) || '0x0000000000000000',
+      isActive: (newRowData.isActive as boolean) || true,
+      payment: (newRowData.payment as number) || 0,
+      email: (newRowData.email as string) || 'new@example.com',
+      status: 'active',
+      address: {
+        addressLine1: (newRowData.address as MockedPerson['address']).addressLine1 || '123 New St',
+        addressLine2: '',
+        city: 'New City',
+        state: 'NY',
+        zip: '00000',
+      },
+    }
+    setData((prev) => [...prev, newRow])
+  }
+
+  const handleDelete = (rows: MockedPerson[]) => {
+    addEventLog('onDelete', `${rows.length} row(s) deleted`, rows)
+
+    // Remove the deleted rows from the data
+    const deletedIds = rows.map((row) => row.id)
+    setData((prev) => prev.filter((row) => !deletedIds.includes(row.id)))
+  }
+
+  const handleCellSave = (fieldName: keyof MockedPerson) => (value: unknown, context: CellContext<MockedPerson>) => {
+    setData((prevData) => {
+      const newData = [...prevData]
+      // Type assertion is needed here since we know the value type matches the field
+      ;(newData[context.rowIndex] as unknown as Record<string, unknown>)[fieldName] = value
+      return newData
+    })
+    return true
+  }
+
+  const columns = useMemo<Array<ColumnDef<MockedPerson>>>(
+    () => [
+      {
+        field: 'firstName',
+        title: 'Name',
+        sortable: true,
+        editable: true,
+        onSave: handleCellSave('firstName'),
+      },
+      {
+        field: 'email',
+        title: 'Email',
+        editable: true,
+        onSave: handleCellSave('email'),
+      },
+      {
+        field: 'payment',
+        title: 'Payment',
+        type: 'currency',
+        sortable: true,
+        editable: true,
+        onSave: handleCellSave('payment'),
+      },
+      {
+        field: 'isActive',
+        title: 'Active',
+        type: 'boolean',
+        editable: true,
+        onSave: handleCellSave('isActive'),
+      },
+      {
+        field: 'status',
+        title: 'Status',
+        sortable: true,
+        editable: true,
+        onSave: handleCellSave('status'),
+        renderCell: (value: string) => (
+          <span
+            className={cn(
+              'px-2 py-1 rounded-full text-xs font-medium',
+              value === 'active' && 'bg-green-100 text-green-700',
+              value === 'inactive' && 'bg-red-100 text-red-700'
+            )}
+          >
+            {value}
+          </span>
+        ),
+      },
+    ],
+    []
+  )
+
+  const actions = useMemo(
+    () => ({
+      primary: {
+        label: 'Edit',
+        callback: () => undefined,
+        icon: <span>✏️</span>,
+      },
+      secondary: [
+        {
+          label: 'View Details',
+          callback: () => undefined,
+        },
+        {
+          label: 'Duplicate',
+          callback: () => undefined,
+        },
+      ],
+    }),
+    []
+  )
+
+  return (
+    <div className="flex gap-6">
+      {/* Table Section */}
+      <div className="flex-1">
+        <h2 className="text-lg font-bold mb-4">Object Set Table with Event Logging</h2>
+        <ObjectSetTable<MockedPerson>
+          columns={columns}
+          data={data}
+          apiRef={apiRef}
+          onAdd={handleAdd}
+          onDelete={handleDelete}
+          //   onReorder={handleReorder}
+          actions={actions}
+          allowRowSelection={true}
+          showRowNumbers={true}
+        />
+      </div>
+
+      {/* Event Log Section */}
+      <EventLogCard eventLogs={eventLogs} clearEventLogs={clearEventLogs} />
+    </div>
+  )
+}
+
+export { EventsExample }

--- a/src/table/logic/public-table-api.ts
+++ b/src/table/logic/public-table-api.ts
@@ -5,7 +5,7 @@ import type { PrivateTableApiBase, TableApiBase } from './types.js'
  * The proxy automatically filters out private methods (those starting with '_')
  * and provides access only to the public interface.
  */
-function createPublicTableApi<TData>(privateApi: PrivateTableApiBase<TData>): TableApiBase {
+function createPublicTableApi<TData>(privateApi: PrivateTableApiBase<TData>): TableApiBase<TData> {
   const mutedMethods = ['_getConfig', '_getState', '_createCellContext']
 
   return new Proxy(privateApi, {
@@ -48,7 +48,7 @@ function createPublicTableApi<TData>(privateApi: PrivateTableApiBase<TData>): Ta
       // Filter out private properties from Object.keys(), etc.
       return Reflect.ownKeys(target).filter((key) => typeof key !== 'string' || !mutedMethods.includes(key))
     },
-  }) as TableApiBase
+  }) as TableApiBase<TData>
 }
 
 export { createPublicTableApi }

--- a/src/table/logic/types.ts
+++ b/src/table/logic/types.ts
@@ -1,5 +1,6 @@
 import type { CellContext, ObjectSetTableConfig, SortDirection } from '../table/types.js'
 import type { TableState } from '../components/table-provider/table-reducer.js'
+import type { TableEventManager } from '../events/index.js'
 
 export interface SortingInfo {
   columnIndex: number
@@ -31,9 +32,10 @@ export interface TableSelectionManager {
   clear(): void
 }
 
-export interface TableApiBase {
+export interface TableApiBase<TData = unknown> {
   // properties
   selection: TableSelectionManager
+  eventManager: TableEventManager<TData>
 
   // methods
   getHTMLTable(): HTMLTableElement | null
@@ -62,7 +64,7 @@ export interface TableApiBase {
   getCurrentSortInfo(): SortingInfo | null
 }
 
-export interface PrivateTableApiBase<TData> extends TableApiBase {
+export interface PrivateTableApiBase<TData> extends TableApiBase<TData> {
   _getConfig(): ObjectSetTableConfig<TData>
   _getState(): TableState<TData>
   _createCellContext(row: number, column: number): CellContext<TData>

--- a/src/table/table/object-set-table.stories.tsx
+++ b/src/table/table/object-set-table.stories.tsx
@@ -19,6 +19,7 @@ import RowReorderingExample from '../examples/row-reordering/row-reordering.js'
  * - [Deletion](?path=/docs/data-display-object-set-table-docs-deletion--readme)
  * - [Sorting & Reordering](?path=/docs/data-display-object-set-table-docs-sorting--readme)
  * - [Actions](?path=/docs/data-display-object-set-table-docs-actions--readme)
+ * - [Events](?path=/docs/data-display-object-set-table-docs-events--readme)
  * - [API](?path=/docs/data-display-object-set-table-docs-api--readme)
  * - [Keyboard Shortcuts](?path=/docs/data-display-object-set-table-docs-keyboard-shortcuts--readme)
  *

--- a/src/table/table/types.ts
+++ b/src/table/table/types.ts
@@ -1,7 +1,7 @@
 import type { TableApiBase } from '../logic/types.js'
 
 export interface ObjectSetTableConfig<T extends DataType> {
-  apiRef?: React.MutableRefObject<TableApiBase | null>
+  apiRef?: React.MutableRefObject<TableApiBase<T> | null>
 
   /**
    * The columns to display in the table.


### PR DESCRIPTION
## Ticket
https://trello.com/c/1ig4QoYK/1054-add-selection-event-listeners-to-objectsettable-rows

## Description
Introduces a comprehensive, type-safe event system for table editing operations.

## Key Features
- **6 core editing events** covering complete editing lifecycle
- **Type-safe event system** with full TypeScript support
- **TableEventManager** class for centralized event management
- **Rich event payloads** with timestamps, coordinates, validation context

## Available Events
| Event | Description |
|-------|-------------|
| `table:editing:start` | Cell enters edit mode |
| `table:editing:save` | Cell edit successfully saved |
| `table:editing:exit` | Exit edit mode (save/cancel) |
| `table:editing:validationError` | Validation fails |
| `table:editing:validationSuccess` | Validation passes |
| `table:editing:validationErrorChange` | Error state changes |

## PR Author Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have performed a self-review of my own chromatic changes and everything is expected
- [ ] I have removed any unnecessary console messages and alerts
- [ ] I have removed any commented code
- [ ] I have checked that there are no dummy or unnecessary comments
- [ ] I have added new test cases (if it applies)
- [ ] I have not introduced any linting issues or warnings

