### PR TITLE
fix(table): improve string default editor & renderer

### DIFF
--- a/src/scalars/components/fragments/textarea-field/textarea-field.test.tsx
+++ b/src/scalars/components/fragments/textarea-field/textarea-field.test.tsx
@@ -130,4 +130,16 @@ describe('TextareaField Component', () => {
       expect(textarea).toHaveValue('Initial')
     })
   })
+
+  describe('Autofocus Behavior', () => {
+    it('should position the cursor at the end when the textarea is auto focused', async () => {
+      renderWithForm(<TextareaField name="textarea" value="Test content" autoFocus />)
+      const textarea = screen.getByRole<HTMLTextAreaElement>('textbox')
+
+      await waitFor(() => {
+        expect(textarea.selectionStart).toBe(12) // Length of "Test content"
+        expect(textarea.selectionEnd).toBe(12)
+      })
+    })
+  })
 })

--- a/src/table/components/default-cell-editors/get-cell-editor-fn.ts
+++ b/src/table/components/default-cell-editors/get-cell-editor-fn.ts
@@ -20,6 +20,8 @@ export const getCellEditorFn = <T extends DataType = DataType>(type?: ColumnType
   switch (type) {
     case 'string':
       return buildStringCellEditor({})
+    case 'string-multiline':
+      return buildStringCellEditor({ multiline: true })
     case 'number':
       return buildNumberCellEditor({})
     case 'boolean':

--- a/src/table/components/default-cell-renderers/get-render-fn.ts
+++ b/src/table/components/default-cell-renderers/get-render-fn.ts
@@ -4,7 +4,8 @@ import { renderCountryCell } from './country-render.js'
 import { renderDateCell } from './date-render.js'
 import { renderDateTimeCell } from './datetime-render.js'
 import { renderNumberCell } from './number-render.js'
-import { renderTextCell } from './text-render.js'
+import { renderStringCell } from './string-render.js'
+import { renderStringMultilineCell } from './string-multiline-render.js'
 import { renderTimeCell } from './time-render.js'
 import { renderUrlCell } from './url-render.js'
 import { renderPhidCell } from './phid-render.js'
@@ -19,7 +20,9 @@ import { renderPhoneCell } from './phone-render.js'
 const getRenderFn = <T>(type: ColumnType | undefined): RenderCellFn<T> => {
   switch (type) {
     case 'string':
-      return renderTextCell
+      return renderStringCell
+    case 'string-multiline':
+      return renderStringMultilineCell
     case 'number':
       return renderNumberCell
     case 'boolean':
@@ -51,9 +54,9 @@ const getRenderFn = <T>(type: ColumnType | undefined): RenderCellFn<T> => {
     case 'phone':
       return renderPhoneCell
     case undefined:
-      return renderTextCell
+      return renderStringCell
     default:
-      return renderTextCell
+      return renderStringCell
   }
 }
 

--- a/src/table/components/default-cell-renderers/string-multiline-render.tsx
+++ b/src/table/components/default-cell-renderers/string-multiline-render.tsx
@@ -1,10 +1,10 @@
 import { cn } from '../../../scalars/lib/utils.js'
 import type { CellContext, DataType } from '../../table/types.js'
 
-const renderTextCell = <T extends DataType = DataType>(value: unknown, context: CellContext<T>) => {
+const renderStringMultilineCell = <T extends DataType = DataType>(value: unknown, context: CellContext<T>) => {
   return (
     <div
-      className={cn({
+      className={cn('whitespace-pre-wrap', {
         'text-right': context.column.align === 'right',
         'text-center': context.column.align === 'center',
         'text-left': context.column.align === 'left' || !context.column.align,
@@ -15,4 +15,4 @@ const renderTextCell = <T extends DataType = DataType>(value: unknown, context: 
   )
 }
 
-export { renderTextCell }
+export { renderStringMultilineCell }

--- a/src/table/components/default-cell-renderers/string-render.tsx
+++ b/src/table/components/default-cell-renderers/string-render.tsx
@@ -1,0 +1,18 @@
+import { cn } from '../../../scalars/lib/utils.js'
+import type { CellContext, DataType } from '../../table/types.js'
+
+const renderStringCell = <T extends DataType = DataType>(value: unknown, context: CellContext<T>) => {
+  return (
+    <div
+      className={cn({
+        'text-right': context.column.align === 'right',
+        'text-center': context.column.align === 'center',
+        'text-left': context.column.align === 'left' || !context.column.align,
+      })}
+    >
+      {value?.toString() ?? ''}
+    </div>
+  )
+}
+
+export { renderStringCell }

--- a/src/table/components/default-fns/default-column-config.ts
+++ b/src/table/components/default-fns/default-column-config.ts
@@ -7,6 +7,7 @@ const defaultColumnAlignment = (columnType: ColumnType): ColumnAlignment => {
       return 'right'
 
     case 'string':
+    case 'string-multiline':
     case 'boolean':
     case 'country':
     case 'enum':

--- a/src/table/components/default-sort-columns/default-sort-fns.ts
+++ b/src/table/components/default-sort-columns/default-sort-fns.ts
@@ -34,6 +34,7 @@ export const defaultSortFns = <T = unknown>(columnType: ColumnType): SortFn<T> =
 
     case 'boolean':
     case 'string':
+    case 'string-multiline':
     case 'country':
     case 'enum':
     case 'currency':

--- a/src/table/docs/col-definition.mdx
+++ b/src/table/docs/col-definition.mdx
@@ -43,9 +43,10 @@ export interface ColumnDef<T> {
 
 The table supports following built-in column types that determine default formatting, rendering, and editing behavior:
 
-| Type        | Scalar Component Rendered                                     |
-| ----------- | ------------------------------------------------------------- |
-| `string`    | [StringField](?path=/docs/scalars-string-field--readme)       |
+| Type              | Scalar Component Rendered                                     |
+| ----------------- | ------------------------------------------------------------- |
+| `string`          | [StringField](?path=/docs/scalars-string-field--readme)       |
+| `string-multiline`| [StringField](?path=/docs/scalars-string-field--readme) (multiline) |
 | `number`    | [NumberField](?path=/docs/scalars-number-field--readme)       |
 | `boolean`   | [BooleanField](?path=/docs/scalars-boolean-field--readme)     |
 | `country`   | [CountryCodeField](?path=/docs/scalars-country-code-field--readme) |

--- a/src/table/table/types.ts
+++ b/src/table/table/types.ts
@@ -135,6 +135,7 @@ export interface RowAction<T extends DataType> {
 
 export type ColumnType =
   | 'string'
+  | 'string-multiline'
   | 'number'
   | 'boolean'
   | 'url'

--- a/src/ui/components/data-entry/textarea/textarea.tsx
+++ b/src/ui/components/data-entry/textarea/textarea.tsx
@@ -1,6 +1,6 @@
 import { sharedValueTransformers } from '../../../../scalars/lib/shared-value-transformers.js'
 import { cn } from '../../../../scalars/lib/utils.js'
-import React, { useEffect, useId, useMemo, useRef } from 'react'
+import React, { useCallback, useEffect, useId, useMemo, useRef } from 'react'
 import { useResizeObserver } from 'usehooks-ts'
 import { CharacterCounter } from '../../../../scalars/components/fragments/character-counter/index.js'
 import { FormDescription } from '../../../../scalars/components/fragments/form-description/index.js'
@@ -50,6 +50,7 @@ const textareaBaseStyles = cn(
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   (
     {
+      autoFocus,
       autoComplete,
       autoExpand,
       multiline = true,
@@ -65,6 +66,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       name,
       onChange,
       onKeyDown,
+      onFocus,
       placeholder,
       required,
       rows = 3,
@@ -128,7 +130,6 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       if (!multiline && e.key === 'Enter') {
         e.preventDefault()
       }
-      // Call the original onKeyDown
       onKeyDown?.(e)
     }
 
@@ -136,9 +137,22 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       if (autoExpand) {
         adjustHeight()
       }
-      // Call the original onChange
       onChange?.(e)
     }
+
+    const handleOnFocus = useCallback(
+      (e: React.FocusEvent<HTMLTextAreaElement>) => {
+        // Position the cursor at the end when the textarea is auto focused
+        if (autoFocus && e.target.value !== '') {
+          const length = e.target.value.length
+          setTimeout(() => {
+            e.target.setSelectionRange(length, length)
+          }, 0)
+        }
+        onFocus?.(e)
+      },
+      [autoFocus, onFocus]
+    )
 
     useEffect(() => {
       if (autoExpand) {
@@ -203,6 +217,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
                 rows={multiline ? rows : 1}
                 onChange={handleOnChange}
                 onKeyDown={handleKeyDown}
+                onFocus={handleOnFocus}
                 {...props}
               />
             </ValueTransformer>


### PR DESCRIPTION
## Ticket
https://trello.com/c/7Q389yX6/939-create-default-editor-render-for-components-types-objectsettable

## Description
- Improve the default String editor and renderer (adds support for multiline strings)
- Fix cursor positioning in the Textarea when it is auto focused

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings