### PR TITLE
feat(table): add event support for sort state changes

### DIFF
--- a/src/table/docs/events.mdx
+++ b/src/table/docs/events.mdx
@@ -37,6 +37,13 @@ The Table dispatches DOM events for all operations. Events are type-safe and inc
 | `table:delete:cancel` | Deletion cancelled | `rowIndexes[]`, `rowsData[]`, `rowCount`, `reason` |
 | `table:delete:error` | Deletion failed | `rowIndexes[]`, `rowsData[]`, `rowCount`, `error` |
 
+#### Sort Events
+
+| Event | When | Key Payload Fields |
+|-------|------|-------------------|
+| `table:sort:change` | Column sort direction changes | `columnIndex`, `columnDef`, `previousDirection`, `newDirection`, `previousColumnIndex`, `sortState`, `dataCount` |
+| `table:sort:clear` | Column sorting is cleared | `columnIndex`, `columnDef`, `previousSortState`, `dataCount` |
+
 **Common Payload Fields:**
 
 *Editing Events:*
@@ -58,6 +65,12 @@ The Table dispatches DOM events for all operations. Events are type-safe and inc
 - `rowIndexes: number[]` - Array of row positions being deleted
 - `rowsData: TData[]` - Array of complete row data being deleted
 - `rowCount: number` - Number of rows being deleted
+
+*Sort Events:*
+- `timestamp: Date` - When event occurred
+- `columnIndex: number` - Column position (0-based)
+- `columnDef: ColumnDef<TData>` - Column configuration
+- `dataCount: number` - Total number of rows in the table
 
 ---
 

--- a/src/table/events/index.ts
+++ b/src/table/events/index.ts
@@ -19,6 +19,8 @@ export type {
   InsertStartEvent,
   InsertSuccessEvent,
   InsertCancelEvent,
+  SortChangeEvent,
+  SortClearEvent,
   TableEventPayload,
   TableEventMap,
   TableEventListener,

--- a/src/table/events/table-event-manager.ts
+++ b/src/table/events/table-event-manager.ts
@@ -10,6 +10,8 @@ import type {
   InsertCancelEvent,
   InsertStartEvent,
   InsertSuccessEvent,
+  SortChangeEvent,
+  SortClearEvent,
   TableEventMap,
   ValidationErrorChangeEvent,
   ValidationErrorEvent,
@@ -195,6 +197,26 @@ export class TableEventManager<TData = unknown> {
    */
   triggerInsertCancel(payload: Omit<InsertCancelEvent<TData>, 'timestamp'>): void {
     this.triggerEvent('table:insert:cancel', {
+      ...payload,
+      timestamp: new Date(),
+    })
+  }
+
+  /**
+   * Triggers when column sort direction changes
+   */
+  triggerSortChange(payload: Omit<SortChangeEvent<TData>, 'timestamp'>): void {
+    this.triggerEvent('table:sort:change', {
+      ...payload,
+      timestamp: new Date(),
+    })
+  }
+
+  /**
+   * Triggers when column sorting is cleared
+   */
+  triggerSortClear(payload: Omit<SortClearEvent<TData>, 'timestamp'>): void {
+    this.triggerEvent('table:sort:clear', {
       ...payload,
       timestamp: new Date(),
     })

--- a/src/table/events/types.ts
+++ b/src/table/events/types.ts
@@ -349,6 +349,62 @@ export interface InsertCancelEvent<TData = unknown> extends BaseCellEvent<TData>
 }
 
 /**
+ * Event triggered when column sort direction changes
+ */
+export interface SortChangeEvent<TData = unknown> extends BaseColumnEvent {
+  /**
+   * The column index where the sort change occurred
+   */
+  columnIndex: number
+  /**
+   * The column definition for the sorted column
+   */
+  columnDef: ColumnDef<TData>
+  /**
+   * The previous sort direction (null if no previous sort)
+   */
+  previousDirection: 'asc' | 'desc' | null
+  /**
+   * The new sort direction (null if sorting is being cleared)
+   */
+  newDirection: 'asc' | 'desc' | null
+  /**
+   * The previous column index that was sorted (null if no previous sort)
+   */
+  previousColumnIndex: number | null
+  /**
+   * The current sort state (null if no sorting is applied)
+   */
+  sortState: { columnIndex: number; direction: 'asc' | 'desc' } | null
+  /**
+   * The total number of rows in the table
+   */
+  dataCount: number
+}
+
+/**
+ * Event triggered when column sorting is cleared
+ */
+export interface SortClearEvent<TData = unknown> extends BaseColumnEvent {
+  /**
+   * The column index where the sort was cleared
+   */
+  columnIndex: number
+  /**
+   * The column definition for the column that was sorted
+   */
+  columnDef: ColumnDef<TData>
+  /**
+   * The previous sort state that was cleared
+   */
+  previousSortState: { columnIndex: number; direction: 'asc' | 'desc' }
+  /**
+   * The total number of rows in the table
+   */
+  dataCount: number
+}
+
+/**
  * Union type of all possible table event payloads
  */
 export type TableEventPayload<TData = unknown> =
@@ -366,6 +422,8 @@ export type TableEventPayload<TData = unknown> =
   | InsertStartEvent<TData>
   | InsertSuccessEvent<TData>
   | InsertCancelEvent<TData>
+  | SortChangeEvent<TData>
+  | SortClearEvent<TData>
 
 /**
  * Mapping of event names to their payload types
@@ -385,6 +443,8 @@ export interface TableEventMap<TData = unknown> {
   'table:insert:start': InsertStartEvent<TData>
   'table:insert:success': InsertSuccessEvent<TData>
   'table:insert:cancel': InsertCancelEvent<TData>
+  'table:sort:change': SortChangeEvent<TData>
+  'table:sort:clear': SortClearEvent<TData>
 }
 
 /**

--- a/src/table/examples/events/events.tsx
+++ b/src/table/examples/events/events.tsx
@@ -172,6 +172,37 @@ const EventsExample = () => {
       )
     }) as EventListener
 
+    // Sort event handlers
+    const handleSortChange = ((event: CustomEvent<TableEventMap<MockedPerson>['table:sort:change']>) => {
+      const { columnDef, previousDirection, newDirection, previousColumnIndex } = event.detail
+      const directionText = (dir: string | null) => {
+        switch (dir) {
+          case 'asc':
+            return 'ascending'
+          case 'desc':
+            return 'descending'
+          case null:
+            return 'none'
+          default:
+            return 'none'
+        }
+      }
+
+      let details = `Sort changed for column "${columnDef.field}"`
+      if (previousColumnIndex !== null && previousColumnIndex !== event.detail.columnIndex) {
+        details += ` (switched from column ${previousColumnIndex})`
+      }
+      details += `: ${directionText(previousDirection)} → ${directionText(newDirection)}`
+
+      addEventLog('sort:change', details, event.detail)
+    }) as EventListener
+
+    const handleSortClear = ((event: CustomEvent<TableEventMap<MockedPerson>['table:sort:clear']>) => {
+      const { columnDef, previousSortState } = event.detail
+      const directionText = previousSortState.direction === 'asc' ? 'ascending' : 'descending'
+      addEventLog('sort:clear', `Sort cleared for column "${columnDef.field}" (was ${directionText})`, event.detail)
+    }) as EventListener
+
     const tableElement = api.getHTMLTable()!
     tableElement.addEventListener('table:editing:start', handleEditingStart)
     tableElement.addEventListener('table:editing:save', handleEditingSave)
@@ -187,6 +218,8 @@ const EventsExample = () => {
     tableElement.addEventListener('table:delete:success', handleDeleteSuccess)
     tableElement.addEventListener('table:delete:cancel', handleDeleteCancel)
     tableElement.addEventListener('table:delete:error', handleDeleteError)
+    tableElement.addEventListener('table:sort:change', handleSortChange)
+    tableElement.addEventListener('table:sort:clear', handleSortClear)
 
     return () => {
       // Cleanup event listeners
@@ -204,6 +237,8 @@ const EventsExample = () => {
       tableElement.removeEventListener('table:delete:success', handleDeleteSuccess)
       tableElement.removeEventListener('table:delete:cancel', handleDeleteCancel)
       tableElement.removeEventListener('table:delete:error', handleDeleteError)
+      tableElement.removeEventListener('table:sort:change', handleSortChange)
+      tableElement.removeEventListener('table:sort:clear', handleSortClear)
     }
   }, [])
 

--- a/src/table/logic/table-api.ts
+++ b/src/table/logic/table-api.ts
@@ -498,7 +498,7 @@ class TableApi<TData> implements PrivateTableApiBase<TData> {
 
     this._getState().dispatch?.({
       type: 'SORT_COLUMN',
-      payload: { columnIndex, direction, tableConfig: this._getConfig() },
+      payload: { columnIndex, direction, tableConfig: this._getConfig(), eventManager: this.eventManager },
     })
   }
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/1ig4QoYK/1054-add-selection-event-listeners-to-objectsettable-rows

## Description
This PR adds comprehensive event support for table sort state changes, enabling applications to listen and respond to sorting events in the table component.

### Changes Made:
- **Table Reducer**: Enhanced `table-reducer.tsx` with sort state change handling and event triggering
- **Event System**: Extended event types and manager in `table-event-manager.ts` and `types.ts` to support sort events
- **Documentation**: Updated `events.mdx` with comprehensive documentation for the new sort event functionality
- **Examples**: Enhanced `events.tsx` example to demonstrate sort event handling
- **API Integration**: Minor updates to `table-api.ts` for proper event integration
- **Export Updates**: Updated `index.ts` to export new event types

### Technical Details:
- Added new event types for sort state changes
- Implemented event triggering in the table reducer when sort state changes
- Enhanced event manager to handle sort-specific events
- Updated documentation with examples and usage patterns
- Maintained backward compatibility with existing event system

## PR Author Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes and everything is expected
- [x] I have removed any unnecessary console messages and alerts
- [x] I have removed any commented code
- [x] I have checked that there are no dummy or unnecessary comments
- [x] I have added new test cases (if it applies)
- [x] I have not introduced any linting issues or warnings

## Screenshots (if apply)