### PR TITLE
fix(table): improve default cell renderers and editors

### DIFF
--- a/src/table/components/default-cell-editors/aid-editor.tsx
+++ b/src/table/components/default-cell-editors/aid-editor.tsx
@@ -9,7 +9,7 @@ export const buildAidCellEditor = <T extends DataType>(
     const aidValue = normalizeStringValue(value)
 
     if (aidFieldProps.autoComplete !== false && aidFieldProps.fetchOptionsCallback) {
-      const { autoComplete: _, fetchOptionsCallback, ...restProps } = aidFieldProps
+      const { autoComplete: _1, fetchOptionsCallback, ...restProps } = aidFieldProps
 
       return (
         <AIDField

--- a/src/table/components/default-cell-editors/currency-editor.tsx
+++ b/src/table/components/default-cell-editors/currency-editor.tsx
@@ -1,12 +1,15 @@
-import { CurrencyCodeField } from '../../../scalars/components/currency-code-field/currency-code-field.js'
-import type { CurrencyCodeFieldProps } from '../../../scalars/components/currency-code-field/types.js'
+import {
+  CurrencyCodeField,
+  type CurrencyCodeFieldProps,
+} from '../../../scalars/components/currency-code-field/index.js'
+import { normalizeStringValue } from './utils.js'
 import type { CellContext, DataType } from '../../table/types.js'
 
 export const buildCurrencyCellEditor = <T extends DataType>(
   currencyFieldProps: Omit<CurrencyCodeFieldProps, 'name' | 'value' | 'onChange'>
 ) => {
   const CurrencyCellEditor = (value: unknown, onChange: (newValue: unknown) => void, context: CellContext<T>) => {
-    const currencyValue = typeof value === 'string' ? value : String(value ?? '')
+    const currencyValue = normalizeStringValue(value)
 
     return (
       <CurrencyCodeField

--- a/src/table/components/default-cell-editors/oid-editor.tsx
+++ b/src/table/components/default-cell-editors/oid-editor.tsx
@@ -1,21 +1,38 @@
-import { OIDField } from '../../../scalars/components/oid-field/oid-field.js'
-import type { OIDFieldProps } from '../../../scalars/components/oid-field/types.js'
+import { OIDField, type OIDFieldProps } from '../../../scalars/components/oid-field/index.js'
+import { normalizeStringValue } from './utils.js'
 import type { CellContext, DataType } from '../../table/types.js'
 
 export const buildOidCellEditor = <T extends DataType>(
-  oidFieldProps: Omit<
-    OIDFieldProps,
-    | 'name'
-    | 'value'
-    | 'onChange'
-    | 'autoComplete'
-    | 'fetchOptionsCallback'
-    | 'fetchSelectedOptionCallback'
-    | 'previewPlaceholder'
-  >
+  oidFieldProps: Omit<OIDFieldProps, 'name' | 'value' | 'onChange'>
 ) => {
   const OidCellEditor = (value: unknown, onChange: (newValue: unknown) => void, context: CellContext<T>) => {
-    const oidValue = typeof value === 'string' ? value : String(value ?? '')
+    const oidValue = normalizeStringValue(value)
+
+    if (oidFieldProps.autoComplete !== false && oidFieldProps.fetchOptionsCallback) {
+      const { autoComplete: _1, fetchOptionsCallback, ...restProps } = oidFieldProps
+
+      return (
+        <OIDField
+          name={context.column.field}
+          className="max-w-full"
+          autoFocus
+          fetchOptionsCallback={fetchOptionsCallback}
+          {...restProps}
+          value={oidValue}
+          onChange={(value) => {
+            onChange(value)
+          }}
+        />
+      )
+    }
+
+    const {
+      autoComplete: _1,
+      fetchOptionsCallback: _2,
+      fetchSelectedOptionCallback: _3,
+      previewPlaceholder: _4,
+      ...restProps
+    } = oidFieldProps
 
     return (
       <OIDField
@@ -23,9 +40,9 @@ export const buildOidCellEditor = <T extends DataType>(
         className="max-w-full"
         autoFocus
         autoComplete={false}
-        {...oidFieldProps}
+        {...restProps}
         value={oidValue}
-        onChange={(value: string) => {
+        onChange={(value) => {
           onChange(value)
         }}
       />

--- a/src/table/components/default-cell-editors/phid-editor.tsx
+++ b/src/table/components/default-cell-editors/phid-editor.tsx
@@ -1,23 +1,41 @@
-import { PHIDField } from '../../../scalars/components/phid-field/phid-field.js'
-import type { PHIDFieldProps } from '../../../scalars/components/phid-field/types.js'
+import { PHIDField, type PHIDFieldProps } from '../../../scalars/components/phid-field/index.js'
+import { normalizeStringValue } from './utils.js'
 import type { CellContext, DataType } from '../../table/types.js'
 
 export const buildPhidCellEditor = <T extends DataType>(
-  phidFieldProps: Omit<
-    PHIDFieldProps,
-    | 'name'
-    | 'value'
-    | 'onChange'
-    | 'autoComplete'
-    | 'allowUris'
-    | 'allowedScopes'
-    | 'fetchOptionsCallback'
-    | 'fetchSelectedOptionCallback'
-    | 'previewPlaceholder'
-  >
+  phidFieldProps: Omit<PHIDFieldProps, 'name' | 'value' | 'onChange'>
 ) => {
   const PhidCellEditor = (value: unknown, onChange: (newValue: unknown) => void, context: CellContext<T>) => {
-    const phidValue = typeof value === 'string' ? value : String(value ?? '')
+    const phidValue = normalizeStringValue(value)
+
+    if (phidFieldProps.autoComplete !== false && phidFieldProps.fetchOptionsCallback) {
+      const { autoComplete: _1, fetchOptionsCallback, allowUris, allowedScopes, ...restProps } = phidFieldProps
+
+      return (
+        <PHIDField
+          name={context.column.field}
+          className="max-w-full"
+          autoFocus
+          fetchOptionsCallback={fetchOptionsCallback}
+          {...(allowUris ? { allowUris: true, allowedScopes } : { allowUris: undefined })}
+          {...restProps}
+          value={phidValue}
+          onChange={(value) => {
+            onChange(value)
+          }}
+        />
+      )
+    }
+
+    const {
+      autoComplete: _1,
+      fetchOptionsCallback: _2,
+      fetchSelectedOptionCallback: _3,
+      previewPlaceholder: _4,
+      allowUris,
+      allowedScopes,
+      ...restProps
+    } = phidFieldProps
 
     return (
       <PHIDField
@@ -25,10 +43,10 @@ export const buildPhidCellEditor = <T extends DataType>(
         className="max-w-full"
         autoFocus
         autoComplete={false}
-        allowUris={false}
-        {...phidFieldProps}
+        {...(allowUris ? { allowUris: true, allowedScopes } : { allowUris: undefined })}
+        {...restProps}
         value={phidValue}
-        onChange={(value: string) => {
+        onChange={(value) => {
           onChange(value)
         }}
       />

--- a/src/table/components/default-cell-renderers/aid-render.tsx
+++ b/src/table/components/default-cell-renderers/aid-render.tsx
@@ -4,11 +4,15 @@ import type { CellContext, DataType } from '../../table/types.js'
 const renderAidCell = <T extends DataType = DataType>(value: unknown, context: CellContext<T>) => {
   return (
     <div
-      className={cn({
-        'text-right': context.column.align === 'right',
-        'text-center': context.column.align === 'center',
-        'text-left': context.column.align === 'left' || !context.column.align,
-      })}
+      className={cn(
+        {
+          'text-right': context.column.align === 'right',
+          'text-center': context.column.align === 'center',
+          'text-left': context.column.align === 'left' || !context.column.align,
+        },
+        'truncate'
+      )}
+      style={{ maxWidth: context.column.maxWidth ?? context.column.width }}
     >
       {value?.toString() ?? ''}
     </div>

--- a/src/table/components/default-cell-renderers/amount-render.tsx
+++ b/src/table/components/default-cell-renderers/amount-render.tsx
@@ -1,16 +1,36 @@
 import { cn } from '../../../scalars/lib/utils.js'
 import type { CellContext, DataType } from '../../table/types.js'
+import type { Amount } from '../../../ui/components/data-entry/amount-input/types.js'
 
 const renderAmountCell = <T extends DataType = DataType>(value: unknown, context: CellContext<T>) => {
+  const formatAmount = (rawValue: unknown): string => {
+    if (typeof rawValue === 'object' && rawValue !== null && 'value' in rawValue) {
+      const amount = rawValue as Amount
+      if (amount.value !== undefined && amount.unit) {
+        return `${amount.value} ${amount.unit}`
+      }
+      if (amount.value !== undefined) {
+        return amount.value.toString()
+      }
+    }
+    if (typeof rawValue === 'number') {
+      return rawValue.toString()
+    }
+    return ''
+  }
+
   return (
     <div
-      className={cn({
-        'text-right': context.column.align === 'right',
-        'text-center': context.column.align === 'center',
-        'text-left': context.column.align === 'left' || !context.column.align,
-      })}
+      className={cn(
+        {
+          'text-right': context.column.align === 'right',
+          'text-center': context.column.align === 'center',
+          'text-left': context.column.align === 'left' || !context.column.align,
+        },
+        'font-semibold'
+      )}
     >
-      {value?.toString() ?? ''}
+      {formatAmount(value)}
     </div>
   )
 }

--- a/src/table/components/default-cell-renderers/currency-render.tsx
+++ b/src/table/components/default-cell-renderers/currency-render.tsx
@@ -4,11 +4,14 @@ import type { CellContext, DataType } from '../../table/types.js'
 const renderCurrencyCell = <T extends DataType = DataType>(value: unknown, context: CellContext<T>) => {
   return (
     <div
-      className={cn({
-        'text-right': context.column.align === 'right',
-        'text-center': context.column.align === 'center',
-        'text-left': context.column.align === 'left' || !context.column.align,
-      })}
+      className={cn(
+        {
+          'text-right': context.column.align === 'right',
+          'text-center': context.column.align === 'center',
+          'text-left': context.column.align === 'left' || !context.column.align,
+        },
+        'font-semibold'
+      )}
     >
       {value?.toString() ?? ''}
     </div>

--- a/src/table/components/default-cell-renderers/date-render.tsx
+++ b/src/table/components/default-cell-renderers/date-render.tsx
@@ -17,11 +17,14 @@ const renderDateCell = <T extends DataType = DataType>(value: unknown, context: 
 
   return (
     <div
-      className={cn({
-        'text-right': context.column.align === 'right',
-        'text-center': context.column.align === 'center',
-        'text-left': context.column.align === 'left' || !context.column.align,
-      })}
+      className={cn(
+        {
+          'text-right': context.column.align === 'right',
+          'text-center': context.column.align === 'center',
+          'text-left': context.column.align === 'left' || !context.column.align,
+        },
+        'font-semibold'
+      )}
     >
       {formatDate(value)}
     </div>

--- a/src/table/components/default-cell-renderers/datetime-render.tsx
+++ b/src/table/components/default-cell-renderers/datetime-render.tsx
@@ -17,11 +17,14 @@ const renderDateTimeCell = <T extends DataType = DataType>(value: unknown, conte
 
   return (
     <div
-      className={cn({
-        'text-right': context.column.align === 'right',
-        'text-center': context.column.align === 'center',
-        'text-left': context.column.align === 'left' || !context.column.align,
-      })}
+      className={cn(
+        {
+          'text-right': context.column.align === 'right',
+          'text-center': context.column.align === 'center',
+          'text-left': context.column.align === 'left' || !context.column.align,
+        },
+        'font-semibold'
+      )}
     >
       {formatDateTime(value)}
     </div>

--- a/src/table/components/default-cell-renderers/email-render.tsx
+++ b/src/table/components/default-cell-renderers/email-render.tsx
@@ -4,11 +4,14 @@ import type { CellContext, DataType } from '../../table/types.js'
 const renderEmailCell = <T extends DataType = DataType>(value: unknown, context: CellContext<T>) => {
   return (
     <div
-      className={cn({
-        'text-right': context.column.align === 'right',
-        'text-center': context.column.align === 'center',
-        'text-left': context.column.align === 'left' || !context.column.align,
-      })}
+      className={cn(
+        {
+          'text-right': context.column.align === 'right',
+          'text-center': context.column.align === 'center',
+          'text-left': context.column.align === 'left' || !context.column.align,
+        },
+        'break-all'
+      )}
     >
       {value?.toString() ?? ''}
     </div>

--- a/src/table/components/default-cell-renderers/oid-render.tsx
+++ b/src/table/components/default-cell-renderers/oid-render.tsx
@@ -4,11 +4,15 @@ import type { CellContext, DataType } from '../../table/types.js'
 const renderOidCell = <T extends DataType = DataType>(value: unknown, context: CellContext<T>) => {
   return (
     <div
-      className={cn({
-        'text-right': context.column.align === 'right',
-        'text-center': context.column.align === 'center',
-        'text-left': context.column.align === 'left' || !context.column.align,
-      })}
+      className={cn(
+        {
+          'text-right': context.column.align === 'right',
+          'text-center': context.column.align === 'center',
+          'text-left': context.column.align === 'left' || !context.column.align,
+        },
+        'truncate'
+      )}
+      style={{ maxWidth: context.column.maxWidth ?? context.column.width }}
     >
       {value?.toString() ?? ''}
     </div>

--- a/src/table/components/default-cell-renderers/phid-render.tsx
+++ b/src/table/components/default-cell-renderers/phid-render.tsx
@@ -4,11 +4,15 @@ import type { CellContext, DataType } from '../../table/types.js'
 const renderPhidCell = <T extends DataType = DataType>(value: unknown, context: CellContext<T>) => {
   return (
     <div
-      className={cn({
-        'text-right': context.column.align === 'right',
-        'text-center': context.column.align === 'center',
-        'text-left': context.column.align === 'left' || !context.column.align,
-      })}
+      className={cn(
+        {
+          'text-right': context.column.align === 'right',
+          'text-center': context.column.align === 'center',
+          'text-left': context.column.align === 'left' || !context.column.align,
+        },
+        'truncate'
+      )}
+      style={{ maxWidth: context.column.maxWidth ?? context.column.width }}
     >
       {value?.toString() ?? ''}
     </div>

--- a/src/table/components/default-cell-renderers/string-render.tsx
+++ b/src/table/components/default-cell-renderers/string-render.tsx
@@ -4,11 +4,14 @@ import type { CellContext, DataType } from '../../table/types.js'
 const renderStringCell = <T extends DataType = DataType>(value: unknown, context: CellContext<T>) => {
   return (
     <div
-      className={cn({
-        'text-right': context.column.align === 'right',
-        'text-center': context.column.align === 'center',
-        'text-left': context.column.align === 'left' || !context.column.align,
-      })}
+      className={cn(
+        {
+          'text-right': context.column.align === 'right',
+          'text-center': context.column.align === 'center',
+          'text-left': context.column.align === 'left' || !context.column.align,
+        },
+        'break-all'
+      )}
     >
       {value?.toString() ?? ''}
     </div>

--- a/src/table/components/default-cell-renderers/time-render.tsx
+++ b/src/table/components/default-cell-renderers/time-render.tsx
@@ -4,11 +4,14 @@ import type { CellContext, DataType } from '../../table/types.js'
 const renderTimeCell = <T extends DataType = DataType>(value: unknown, context: CellContext<T>) => {
   return (
     <div
-      className={cn({
-        'text-right': context.column.align === 'right',
-        'text-center': context.column.align === 'center',
-        'text-left': context.column.align === 'left' || !context.column.align,
-      })}
+      className={cn(
+        {
+          'text-right': context.column.align === 'right',
+          'text-center': context.column.align === 'center',
+          'text-left': context.column.align === 'left' || !context.column.align,
+        },
+        'font-semibold'
+      )}
     >
       {value?.toString() ?? ''}
     </div>

--- a/src/table/components/default-cell-renderers/url-render.tsx
+++ b/src/table/components/default-cell-renderers/url-render.tsx
@@ -11,18 +11,17 @@ const renderUrlCell = <T extends DataType = DataType>(value: unknown, context: C
         'text-center': context.column.align === 'center',
         'text-left': context.column.align === 'left' || !context.column.align,
       })}
+      style={{ maxWidth: context.column.maxWidth ?? context.column.width }}
     >
-      {url ? (
+      {url && (
         <a
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-blue-900 hover:underline focus-visible:outline-none"
+          className="text-blue-900 hover:underline focus-visible:outline-none truncate block"
         >
           {url}
         </a>
-      ) : (
-        ''
       )}
     </div>
   )

--- a/src/table/components/default-fns/default-cell-value-formatter.ts
+++ b/src/table/components/default-fns/default-cell-value-formatter.ts
@@ -3,8 +3,12 @@ const defaultValueFormatter = (value: unknown) => {
     return ''
   }
 
-  // it is ok if the value is an object and we get something like `[object Object]`
-  // in such case, the developer would have to use a custom value formatter
+  // Handle Amount objects by preserving them instead of converting to string
+  if (typeof value === 'object' && 'value' in value) {
+    return value
+  }
+
+  // For other values, convert to string
   return String(value)
 }
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/7Q389yX6/939-create-default-editor-render-for-components-types-objectsettable

## Description
Improve default cell renderers and editors:

- aid (render & editor)
- oid (render & editor)
- phid (render & editor)
- currency (render & editor)
- amount (render)
- date (render)
- time (render)
- datetime (render)
- email (render)
- string (render)
- url (render)

## PR Author Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have performed a self-review of my own chromatic changes and everything is expected
- [ ] I have removed any unnecessary console messages and alerts
- [ ] I have removed any commented code
- [ ] I have checked that there are no dummy or unnecessary comments
- [ ] I have added new test cases (if it applies)
- [ ] I have not introduced any linting issues or warnings